### PR TITLE
docs(governance): codify branding hygiene policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@
 - Model recoverable failures with `Result` and domain-specific error enums.
 - Keep unsafe code disallowed unless documented with justification and tests.
 
+## Branding and Provenance Hygiene
+- Repository artifacts MUST NOT include Codex, OpenAI, ChatGPT, or other assistant/vendor branding in source code, generated assets, UI copy, comments, docs, tests, fixtures, commit messages, PR text, or issue text unless the material is an intentional third-party reference, legal attribution, or external integration note.
+- When AI tools assist with implementation, contributors must rewrite outputs so they reflect repository terminology and product language rather than tool branding.
+- Placeholder text, scaffolding comments, and generated boilerplate MUST be normalized before merge.
+- Reviewers should treat leaked assistant/vendor branding as a documentation and quality defect that blocks merge until removed or justified.
+
 ## Build, Lint, and Test Standards
 - Required pre-merge quality gates from repository root:
 ```bash
@@ -100,3 +106,4 @@ cargo test --workspace --all-targets
   - verification status.
 - Agents may propose changes outside their domain but may not execute boundary-crossing mutations without policy/workflow authorization.
 - When requirements conflict, agents prioritize contract correctness, policy compliance, and test pass criteria in that order.
+- Agents MUST NOT introduce Codex, OpenAI, ChatGPT, or similar branding into repository artifacts unless explicitly required for a documented third-party reference or legal attribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ All material changes are issue-driven.
 - No direct commits to `main`.
 - PR titles must use conventional commits: `type(scope): description`.
 - The PR body must reference a same-repository issue with `Closes #<issue-id>` or an equivalent issue URL.
+- Source files, docs, UI strings, fixtures, generated assets, commit messages, PR text, and issue text must use repository/product terminology only; do not leak Codex, OpenAI, ChatGPT, or other assistant/vendor branding unless a third-party reference or legal attribution requires it.
 - Required checks must pass before merge.
 - At least one reviewer approval is required before merge.
 - Squash merge is the default merge strategy.
@@ -47,3 +48,5 @@ cargo test --workspace --all-targets
 ```
 
 If your change affects dependency security posture, validate `cargo audit` locally or rely on the `Security Scan` workflow in CI.
+
+During self-review, also remove assistant-generated branding, boilerplate provenance notes, and tool-specific placeholder text before requesting review.

--- a/DEVELOPMENT_MODEL.md
+++ b/DEVELOPMENT_MODEL.md
@@ -74,6 +74,7 @@ Every PR must include:
 - technical changes
 - testing strategy
 - deployment impact
+- repository-native language with no leaked Codex, OpenAI, ChatGPT, or other assistant/vendor branding unless required for an external reference or legal attribution
 
 Merge policy:
 
@@ -147,6 +148,7 @@ Reviewers should confirm:
 - tests or relevant checks pass
 - error handling is explicit
 - contracts and docs are updated when needed
+- assistant/vendor branding has not leaked into code, documentation, UI text, fixtures, commits, issues, or PR content
 
 ## Work-In-Progress Limits
 


### PR DESCRIPTION
## Summary
- add repository-wide branding and provenance hygiene rules to contributor and agent guidance
- require repository-native language in PR content and review checks
- make leaked assistant/vendor branding a blocking quality issue

## Testing
- cargo fmt --all --check

Closes #25