### PR TITLE
docs(ui): extract browser runtime architecture notes

### DIFF
--- a/ui/docs/architecture/browser-capability-matrix.md
+++ b/ui/docs/architecture/browser-capability-matrix.md
@@ -1,0 +1,10 @@
+# Browser Capability Matrix
+
+| Capability | Detection | Status | Fallback |
+| --- | --- | --- | --- |
+| IndexedDB | `platform_host_web::persistence::indexed_db_supported()` | Adopted | Shell can still boot with degraded persistence if browser blocks storage |
+| BroadcastChannel | `platform_host_web::broadcast_channel_supported()` | Adopted | Local-tab only behavior |
+| Service Worker | `platform_host_web::pwa::service_worker_supported()` | Adopted | No offline/install enhancement |
+| File System Access | `platform_host_web::file_access::directory_picker_supported()` | Optional | Origin-scoped storage only |
+| Notifications | Host capability snapshot + browser permission | Optional | No notification delivery |
+| OPFS | `platform_host_web::persistence::opfs_supported()` | Deferred | IndexedDB + Cache API remain authoritative |

--- a/ui/docs/architecture/pwa-runtime-notes.md
+++ b/ui/docs/architecture/pwa-runtime-notes.md
@@ -1,0 +1,6 @@
+# PWA Runtime Notes
+
+- Added `manifest.webmanifest` and linked it from the browser entry HTML.
+- Added `sw.js` and service worker registration from `site/src/pwa.rs`.
+- Offline strategy is intentionally conservative: cache shell root and manifest only.
+- No background sync, push, or mutation-heavy offline workflows were introduced.

--- a/ui/docs/architecture/ui-component-standardization-plan.md
+++ b/ui/docs/architecture/ui-component-standardization-plan.md
@@ -1,0 +1,16 @@
+# UI Component Standardization Plan
+
+## Standardization Decisions
+- Keep `system_ui` as the shared component vocabulary.
+- Use shell CSS to style `data-ui-*` primitives consistently instead of adding app-local control variants.
+- Treat window chrome, taskbar, menus, and field surfaces as part of the same design system.
+
+## Structural Fixes Applied
+- Window frames now respect viewport bounds.
+- Window bodies and content regions scroll instead of clipping.
+- Responsive shell layout turns window layers into stacked flow on narrow viewports.
+- Taskbar and tray strips can overflow horizontally instead of breaking layout.
+
+## Remaining Standardization Targets
+- Further split `desktop_runtime::components` into smaller shell/layout modules.
+- Continue replacing app-local layout/styling fragments with `system_ui` primitives.

--- a/ui/docs/architecture/ui-design-system-plan.md
+++ b/ui/docs/architecture/ui-design-system-plan.md
@@ -1,0 +1,40 @@
+# UI Design System Plan
+
+## Design Principles
+- One authoritative shell language: modern adaptive.
+- Shared primitives own control semantics and states.
+- Browser layouts must degrade into responsive panels rather than broken floating-desktop composition.
+
+## Visual Token Model
+- Dark system-oriented canvas and desktop surfaces.
+- High-contrast text and accent tokens.
+- Shared spacing, radius, elevation, and focus tokens remain centralized in `theme_shell/00-foundations.css`.
+
+## Component Vocabulary
+- `system_ui` primitives remain the source of truth for buttons, menus, fields, taskbar, tray, window frame, panels, and layout primitives.
+- Shell CSS maps those primitives to one visual language instead of several competing theme packs.
+
+## Shell / App Consistency Rules
+- Shell chrome and app surfaces must use the same base surface/border/elevation language.
+- Window bodies and panel content must support scrolling instead of clipping.
+- Responsive rules can change layout, but not component semantics.
+
+## Responsive Behavior Rules
+- Wide viewports may retain multiple shell surfaces and floating windows.
+- Narrower viewports collapse windows into stacked flow and disable resize handles.
+- Taskbar strips and tray regions may scroll horizontally instead of overflowing.
+
+## Interaction State Rules
+- Focus-visible remains explicit.
+- Selected, pressed, disabled, and hover states remain token-driven through shared primitives.
+- Cross-tab state rehydration must not trigger destructive resets.
+
+## Accessibility Rules
+- Maintain explicit focus indicators.
+- Keep text/surface contrast above the prior baseline.
+- Prefer scrollable content over clipped content.
+
+## Anti-Patterns To Remove
+- Multiple active theme packs controlling the same surfaces.
+- Browser-only behavior hidden inside desktop-shaped boot logic.
+- Local styling patches that bypass shared tokens for shell primitives.

--- a/ui/docs/architecture/ui-implementation-notes.md
+++ b/ui/docs/architecture/ui-implementation-notes.md
@@ -1,0 +1,7 @@
+# UI Implementation Notes
+
+- Consolidated the browser shell onto the modern-adaptive CSS bundle.
+- Updated foundational tokens to a darker systems-oriented palette with clearer accent/focus contrast.
+- Added viewport-aware window sizing and overflow handling.
+- Added responsive shell rules that stack windows and simplify shell composition under narrow viewports.
+- Preserved shared primitive ownership in `system_ui`; changes were primarily structural CSS and browser-shell boot behavior.

--- a/ui/docs/architecture/ui-ux-audit.md
+++ b/ui/docs/architecture/ui-ux-audit.md
@@ -1,0 +1,36 @@
+# UI/UX Audit
+
+## Visual Defect Inventory
+- Multiple theme packs produced inconsistent surface tone, depth, and typography hierarchy.
+- Window bodies could clip or overflow because body/content overflow rules were incomplete.
+- Taskbar and menu surfaces did not scale cleanly to narrower browser widths.
+- Browser layout still read as a desktop emulation rather than a web-first shell on smaller viewports.
+
+## Interaction Defect Inventory
+- Browser shell boot logic privileged deep-link desktop opening over route-native browser behavior.
+- Focus-visible and selected states existed at the primitive level, but shell-level consistency varied by surface.
+- Cross-tab browser state changes had no synchronization path.
+
+## Shell Coherence Assessment
+- The shell already had shared primitives, but the runtime still rendered them through a visually mixed theme stack.
+- The modern-adaptive direction existed, but it was not the only authoritative skin.
+
+## Component Consistency Assessment
+- Shared primitives in `system_ui` are the correct ownership point.
+- Shell-level layout defects were mostly structural CSS issues rather than missing primitives.
+- App surfaces should continue moving toward primitive reuse instead of local styling.
+
+## Accessibility Observations
+- Focus-visible styles were already present and retained.
+- Responsive stabilization improved keyboard reachability by avoiding clipped or off-screen window bodies on narrow layouts.
+- The new baseline palette increases contrast between shell background, surfaces, and text.
+
+## Prioritized Remediation
+1. Make one theme authoritative.
+2. Repair window/taskbar/menu overflow and viewport sizing.
+3. Make the browser target responsive instead of fixed-desktop shaped.
+4. Ensure browser-native routes and installability are explicit.
+
+## Before / After Intent
+- Before: browser preview behaved like a desktop shell transplant.
+- After: browser build remains Rust/WASM and shell-based, but behaves like a standards-first web app with shell affordances.

--- a/ui/docs/architecture/wasm-feature-policy.md
+++ b/ui/docs/architecture/wasm-feature-policy.md
@@ -1,0 +1,22 @@
+# WASM Feature Policy
+
+## Required Foundation
+- Stable Rust-to-WASM build.
+- Standard DOM/CSS rendering.
+- IndexedDB for structured browser persistence.
+
+## Optional Features
+- `BroadcastChannel`
+- Service Worker
+- Notifications API
+- File System Access API
+
+## Deferred Features
+- OPFS as a required architectural dependency
+- Navigation API
+- URLPattern
+- OffscreenCanvas
+- WebGPU
+
+## Fallback Rule
+- Optional browser features must fail open to a functional shell, not a broken boot path.

--- a/ui/docs/architecture/wasm-refactor-plan.md
+++ b/ui/docs/architecture/wasm-refactor-plan.md
@@ -1,0 +1,36 @@
+# WASM Refactor Plan
+
+## Per-Crate Refactor Plan
+- `site`: add browser navigation module, service worker registration, browser sync listener, manifest/service-worker assets, and modern-only theme bundle.
+- `platform_host_web`: add browser capability modules, move prefs storage to IndexedDB, add `BroadcastChannel` publication helpers.
+- `desktop_runtime`: export durable boot snapshot loading, stage wallpaper-library hydration after critical boot hydration, and default new themes to modern adaptive.
+
+## Interface Changes
+- `desktop_runtime` re-exports `load_durable_boot_snapshot`.
+- `platform_host_web` exports `cross_context`, `navigation`, `file_access`, `persistence`, and `pwa` helpers.
+- Browser prefs semantics change from `localStorage` to IndexedDB-backed persistence.
+
+## Migration Sequencing
+1. Normalize browser persistence and browser capability helpers.
+2. Replace site route parsing and add PWA/runtime enhancements.
+3. Move shell defaults and responsive CSS to the modern baseline.
+4. Add docs and verification artifacts.
+
+## Risk Notes
+- Browser sync currently targets theme, wallpaper, and layout hydration only.
+- Browser file-access semantics remain optional; the VFS path still exists for compatibility.
+- Legacy skin enums remain in the runtime for compatibility, but the browser shell ships one authoritative theme bundle.
+
+## Compatibility Notes
+- Existing `?open=` deep links still work.
+- Canonical `/notes/:slug` and `/projects/:slug` routes remain browser-first.
+- Desktop/Tauri behavior is preserved.
+
+## Verification Strategy
+- Check `site`, `desktop_runtime`, and `platform_host_web` compilation together.
+- Run focused tests for route parsing and existing host bridge behavior.
+
+## UI Coherence and Design-System Refactor
+- Removed legacy and neumorphic theme CSS from the browser bundle.
+- Updated foundational tokens to a single modern-adaptive palette and type direction.
+- Added window body overflow guards, viewport-constrained window sizing, responsive window stacking, and taskbar overflow handling.

--- a/ui/docs/architecture/wasm-standards-audit.md
+++ b/ui/docs/architecture/wasm-standards-audit.md
@@ -1,0 +1,46 @@
+# WASM Standards Audit
+
+## Current Implementation Summary
+- The browser entrypoint lived in `site/src/web_app.rs` and manually parsed `window.location` query/hash values into desktop deep-link state.
+- Browser host services were already split by capability at the adapter level, but browser semantics were still surfaced through desktop-shaped names such as explorer/filesystem.
+- Browser persistence was mixed: app state in IndexedDB, prefs in `localStorage`, cache in Cache API, and a browser VFS inside the bridge layer.
+- The shell shipped multiple competing theme layers, which caused visual drift and unclear design-system ownership.
+
+## Browser Capability Inventory
+| Capability | Previous State | Current State | Decision |
+| --- | --- | --- | --- |
+| Navigation | Manual query/hash parsing in site entrypoint | Typed browser route adapter in `site/src/browser_navigation.rs` | Standards-aligned, refined |
+| App state | IndexedDB | IndexedDB | Keep |
+| Preferences | `localStorage` | IndexedDB-backed prefs through bridge | Replace |
+| Cache | Cache API | Cache API | Keep |
+| Notifications | Web Notifications API | Web Notifications API | Keep |
+| File-like access | File System Access + IndexedDB VFS | File System Access remains optional, documented as progressive enhancement | Custom but justified |
+| Cross-context sync | None | `BroadcastChannel` shell sync | Replace |
+| Installability | None | manifest + service worker wiring | Replace |
+
+## Keep / Replace Decisions
+- Keep IndexedDB as the structured browser persistence layer.
+- Keep Cache API for derived/static browser cache content.
+- Keep DOM/CSS rendering as the primary shell UI path.
+- Replace browser prefs storage from `localStorage` to IndexedDB-backed storage.
+- Replace manual route/deep-link parsing in the site root with a dedicated browser navigation module.
+- Replace ad hoc same-tab-only state behavior with standards-based `BroadcastChannel` coordination.
+- Keep browser file access capability optional; do not promote the browser VFS as canonical browser semantics.
+
+## Performance Issues
+- Boot hydration previously loaded compatibility snapshot, theme, wallpaper, durable snapshot, and wallpaper library in one async fan-out path.
+- Window shell code still contains large state reads and monolithic component structure in `desktop_runtime::components`.
+- Browser target previously paid extra cost to preserve desktop-preview behavior on small viewports rather than adapting layout structurally.
+
+## Architectural Issues
+- `site/src/web_app.rs` previously owned routing, deep-link parsing, and browser bootstrap logic directly.
+- `platform_host_web` exposed browser behavior primarily through desktop-oriented adapter names.
+- Theme ownership was fragmented across multiple theme packs instead of one authoritative design system.
+- Shell layout and visual behavior were split between reusable primitives and large runtime-owned shell components, which made fixes harder to localize.
+
+## Prioritized Refactor Targets
+1. Browser route handling and shell boot.
+2. IndexedDB-backed prefs and browser persistence normalization.
+3. Cross-tab browser synchronization.
+4. Single-theme visual baseline and responsive shell stabilization.
+5. PWA/installability wiring and explicit browser capability documentation.

--- a/ui/docs/architecture/wasm-target-architecture.md
+++ b/ui/docs/architecture/wasm-target-architecture.md
@@ -1,0 +1,42 @@
+# WASM Target Architecture
+
+## Overview
+- Rust + WebAssembly remains the application core.
+- Browser routing, persistence, installability, and cross-context coordination now use standard browser APIs first.
+- Desktop/Tauri remains the richer host for platform-native capabilities.
+
+## Capability Mapping
+| Domain | Adopted API | Policy |
+| --- | --- | --- |
+| Navigation | `window.location`, router paths, typed route adapter | Required |
+| Structured persistence | IndexedDB | Required |
+| Lightweight prefs | IndexedDB | Required |
+| Cache | Cache API | Required when cache is used |
+| Cross-context sync | `BroadcastChannel` | Optional with no-op fallback |
+| Notifications | Notifications API | Optional with capability gating |
+| File access | File System Access API | Optional progressive enhancement |
+| Installability | Web App Manifest + Service Worker | Optional enhancement for browser builds |
+
+## Desktop vs Browser Split
+- Browser: routing, web installability, origin-scoped persistence, optional file access, standard URL opening.
+- Desktop: Tauri transport, richer native file access, platform-owned notifications, native shell affordances.
+
+## Progressive Enhancement Policy
+- `BroadcastChannel`, notifications, file access, and service worker support are capability-detected.
+- No advanced feature is required to boot the shell.
+- OPFS and WebGPU remain deferred.
+
+## Fallback Policy
+- No `BroadcastChannel`: local-tab behavior only.
+- No service worker: browser shell still runs online.
+- No notifications permission/support: notification requests remain best-effort.
+- No File System Access: browser shell retains origin-scoped storage behavior only.
+
+## API Adoption Decisions
+- Adopted: typed route adapter, IndexedDB prefs, `BroadcastChannel`, manifest/service worker wiring.
+- Deferred: OPFS, Navigation API, URLPattern, OffscreenCanvas, WebGPU.
+
+## Non-Goals
+- No JS-first rewrite.
+- No mandatory worker architecture.
+- No speculative browser filesystem layer beyond optional file access support.

--- a/ui/docs/architecture/wasm-validation-summary.md
+++ b/ui/docs/architecture/wasm-validation-summary.md
@@ -1,0 +1,43 @@
+# WASM Validation Summary
+
+## Objective-by-Objective Assessment
+- Standards-first browser routing: improved.
+- Browser persistence normalization: improved.
+- Cross-context coordination: added.
+- Installability/offline wiring: added.
+- UI coherence: improved through single-theme browser bundle and responsive shell fixes.
+
+## Standards Compliance Summary
+- Browser routing relies on standard location/router behavior.
+- Persistence uses IndexedDB and Cache API.
+- Cross-tab sync uses `BroadcastChannel`.
+- Installability uses manifest + service worker.
+
+## Portability Summary
+- Browser target no longer depends on `localStorage` semantics for prefs.
+- Optional browser capabilities are explicitly gated.
+
+## Performance Summary
+- Boot hydration separates critical state hydration from wallpaper-library loading.
+- Responsive browser layout avoids some desktop-emulation overhead on narrow viewports.
+
+## Maintainability Summary
+- Browser navigation, PWA, and cross-context behavior now live in explicit modules.
+- Required audit and verification docs now exist in `ui/docs`.
+
+## UI Coherence Summary
+- One visual baseline for the browser bundle.
+- Improved layout stability and overflow behavior.
+
+## API Adoption Summary
+- Adopted: IndexedDB prefs, `BroadcastChannel`, manifest/service worker, typed browser route adapter.
+- Deferred: OPFS, WebGPU, Navigation API, URLPattern.
+
+## Final Decision Log
+- Browser UX is web-first.
+- Modern adaptive is the browser design baseline.
+- Desktop-only richer semantics remain isolated to Tauri-hosted behavior.
+
+## Future Follow-Up Recommendations
+- Remove legacy skin/runtime options entirely once compatibility is no longer required.
+- Add browser E2E coverage for service worker registration and cross-tab sync.

--- a/ui/docs/verification/ui-visual-validation.md
+++ b/ui/docs/verification/ui-visual-validation.md
@@ -1,0 +1,36 @@
+# UI Visual Validation
+
+## Surfaces Inspected
+- Shell root
+- Window chrome/body
+- Taskbar
+- Menus
+- Canonical note/project browser pages
+
+## Defects Fixed
+- Window clipping and overflow
+- Window viewport sizing on smaller browsers
+- Taskbar/tray overflow behavior
+- Theme inconsistency caused by multiple active browser theme bundles
+
+## Consistency Checks
+- Shared shell surfaces use one palette and elevation model.
+- Window, taskbar, and menu surfaces now read as one system.
+
+## Responsive Checks
+- Narrow layouts stack windows.
+- Desktop icon strip becomes horizontally scrollable instead of breaking layout.
+- Taskbar sections collapse into a single-column flow on small widths.
+
+## Accessibility Checks
+- Focus-visible styles preserved.
+- Higher-contrast shell palette applied.
+- Scroll-based access replaces clipped content regions.
+
+## Remaining Visual Debt
+- Runtime shell component structure is still larger than ideal.
+- Built-in app internals still need more primitive-level normalization.
+
+## Recommended Next-Pass Polish
+- Split `desktop_runtime::components` further.
+- Add screenshots or browser E2E visual assertions for shell breakpoints.

--- a/ui/docs/verification/wasm-refactor-verification.md
+++ b/ui/docs/verification/wasm-refactor-verification.md
@@ -1,0 +1,34 @@
+# WASM Refactor Verification
+
+## Commands Run
+- `cargo fmt --all --check`
+- `cargo clippy -p site -p desktop_runtime -p platform_host_web --all-targets -- -D warnings`
+- `cargo check -p site -p desktop_runtime -p platform_host_web`
+- `cargo test -p site -p platform_host_web -p system_ui --no-default-features --features csr`
+
+## Targets Built
+- `site`
+- `desktop_runtime`
+- `platform_host_web`
+- `system_ui`
+
+## Tests Added Or Updated
+- Added browser route parsing tests in `site/src/browser_navigation.rs`.
+- Retained existing bridge/service tests in `platform_host_web`.
+
+## Manual Validation Checklist
+- Browser shell boots with route-native note/project pages.
+- `?open=` compatibility still resolves to shell deep links.
+- Browser build exposes manifest and service worker assets.
+- Narrow browser layouts stack windows and preserve scrollability.
+
+## Fallback Validation Results
+- Non-wasm bridge tests still pass for host adapters.
+- Browser optional features remain capability-gated.
+
+## Known Limitations
+- Full workspace `cargo clippy --workspace` and `cargo test --workspace` were not run in this pass.
+- Service worker strategy is intentionally minimal.
+
+## Unresolved Risks
+- Cross-tab sync currently covers theme, wallpaper, and layout hydration only.


### PR DESCRIPTION
## Summary
- extract the `ui/docs/` material from PR #43 into a standalone documentation review
- keep architecture, audit, planning, and verification notes together without runtime changes
- leave browser/runtime implementation work for a separate follow-up PR

## Notes
- this PR contains only `ui/docs/**` changes
- extracted from the mixed browser/runtime branch in PR #43
