### PR TITLE
fix(ui): restore browser preview startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7100,6 +7100,7 @@ dependencies = [
  "console_error_panic_hook",
  "desktop_app_contract",
  "desktop_runtime",
+ "js-sys",
  "leptos",
  "leptos_meta",
  "leptos_router",

--- a/ui/crates/platform_host_web/Cargo.toml
+++ b/ui/crates/platform_host_web/Cargo.toml
@@ -17,6 +17,6 @@ serde_json = "1"
 serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["Blob", "BroadcastChannel", "Document", "Event", "File", "FileList", "FileReader", "HtmlElement", "HtmlInputElement", "MessageEvent", "Notification", "ProgressEvent", "Storage", "Url", "Window"] }
+web-sys = { version = "0.3", features = ["Blob", "BroadcastChannel", "Document", "Event", "File", "FileList", "FileReader", "HtmlElement", "HtmlInputElement", "MessageEvent", "Navigator", "Notification", "ProgressEvent", "Storage", "StorageManager", "Url", "Window"] }
 
 [dev-dependencies]

--- a/ui/crates/site/Cargo.toml
+++ b/ui/crates/site/Cargo.toml
@@ -19,6 +19,7 @@ desktop-tauri = ["desktop_runtime/desktop-tauri", "platform_host_web/desktop-hos
 [dependencies]
 desktop_app_contract = { path = "../desktop_app_contract" }
 desktop_runtime = { path = "../desktop_runtime", default-features = false }
+js-sys = "0.3"
 leptos = { version = "0.6", default-features = false }
 leptos_meta = { version = "0.6", default-features = false }
 leptos_router = { version = "0.6", default-features = false }

--- a/ui/crates/site/index.html
+++ b/ui/crates/site/index.html
@@ -15,5 +15,6 @@
   </head>
   <body>
     <noscript>Origin OS requires JavaScript and WebAssembly support.</noscript>
+    <div id="app"></div>
   </body>
   </html>

--- a/ui/crates/site/src/lib.rs
+++ b/ui/crates/site/src/lib.rs
@@ -21,5 +21,15 @@ pub use web_app::{DesktopEntry, SiteApp};
 /// `csr` feature enabled.
 pub fn mount() {
     console_error_panic_hook::set_once();
-    leptos::mount_to_body(|| leptos::view! { <SiteApp /> })
+    use wasm_bindgen::JsCast;
+
+    let document = web_sys::window()
+        .and_then(|window| window.document())
+        .expect("window document should be available for CSR mount");
+    let app_root = document
+        .get_element_by_id("app")
+        .expect("site app root element should exist")
+        .dyn_into::<web_sys::HtmlElement>()
+        .expect("site app root should be an HtmlElement");
+    leptos::mount_to(app_root, || leptos::view! { <SiteApp /> })
 }

--- a/ui/crates/site/src/pwa.rs
+++ b/ui/crates/site/src/pwa.rs
@@ -20,7 +20,7 @@ fn public_asset_path(base_path: &str, asset: &str) -> String {
 #[cfg(target_arch = "wasm32")]
 fn current_public_base_path() -> Option<String> {
     let document = web_sys::window()?.document()?;
-    let base_uri = document.base_uri().ok()?;
+    let base_uri = document.base_uri().ok().flatten()?;
     let url = web_sys::Url::new(&base_uri).ok()?;
     Some(url.pathname())
 }

--- a/ui/crates/site/src/web_app.rs
+++ b/ui/crates/site/src/web_app.rs
@@ -107,8 +107,8 @@ fn BrowserShellSync() -> impl IntoView {
             let runtime = _runtime.clone();
             let host = host.clone();
 
-            let callback =
-                Closure::<dyn FnMut(web_sys::MessageEvent)>::wrap(Box::new(move |event| {
+            let callback = Closure::<dyn FnMut(web_sys::MessageEvent)>::wrap(Box::new(
+                move |event: web_sys::MessageEvent| {
                     let Some(message) = event.data().as_string() else {
                         return;
                     };
@@ -147,7 +147,8 @@ fn BrowserShellSync() -> impl IntoView {
                         }
                         _ => {}
                     }
-                }));
+                },
+            ));
 
             channel.set_onmessage(Some(callback.as_ref().unchecked_ref()));
 


### PR DESCRIPTION
## Summary
Restore the browser preview startup path used by `cargo ui-dev`.

## Linked Issue
Closes #49

## Technical Changes
- enable the `web-sys` bindings needed for browser storage capability detection in `platform_host_web`
- add the missing `js-sys` dependency and correct the browser-side `site` runtime code paths
- mount the Leptos `site` application into a dedicated `#app` element instead of mounting directly to `body`
- keep the Trunk-served preview HTML aligned with the explicit mount target

## Testing Strategy
- `cargo check -p site --target wasm32-unknown-unknown`
- verified `cargo ui-dev` starts successfully and serves the preview page with the dedicated app mount root

## Deployment Impact
Low. Changes are limited to the browser preview host and `ui/crates/site` startup path.
