### PR TITLE
fix(ui): rebase runtime remediation onto hardened main

### DIFF
--- a/ui/crates/apps/control_center/src/lib.rs
+++ b/ui/crates/apps/control_center/src/lib.rs
@@ -74,9 +74,10 @@ pub fn ControlCenterApp(
         }
     }
 
+    let state_service = services.state.clone();
     create_effect(move |_| {
         if let Ok(serialized) = serde_json::to_value(state.get()) {
-            services.state.persist_window_state(serialized);
+            state_service.persist_window_state(serialized);
         }
     });
 

--- a/ui/crates/apps/settings/src/lib.rs
+++ b/ui/crates/apps/settings/src/lib.rs
@@ -124,9 +124,10 @@ pub fn SettingsApp(
         settings_state.update(|state| state.active_section = section);
     }
 
+    let state_service = services.state.clone();
     create_effect(move |_| {
         if let Ok(serialized) = serde_json::to_value(settings_state.get()) {
-            services.state.persist_window_state(serialized);
+            state_service.persist_window_state(serialized);
         }
     });
 

--- a/ui/crates/apps/terminal/src/lib.rs
+++ b/ui/crates/apps/terminal/src/lib.rs
@@ -413,8 +413,9 @@ pub fn TerminalApp(
         last_saved.set(Some(serialized));
 
         if let Some(services) = services_for_persist.clone() {
+            let state_service = services.state.clone();
             if let Ok(value) = serde_json::to_value(&snapshot) {
-                services.state.persist_window_state(value);
+                state_service.persist_window_state(value);
             }
         }
     });

--- a/ui/crates/desktop_app_contract/src/lib.rs
+++ b/ui/crates/desktop_app_contract/src/lib.rs
@@ -14,10 +14,10 @@
 
 #![warn(missing_docs, rustdoc::broken_intra_doc_links)]
 
-use std::{cell::Cell, rc::Rc};
+use std::{cell::Cell, collections::BTreeMap, rc::Rc};
 
 use futures::future::LocalBoxFuture;
-use leptos::{Callable, Callback, ReadSignal, RwSignal, View};
+use leptos::{Callable, Callback, ReadSignal, RwSignal, SignalGet, View};
 use platform_host::{
     load_app_state_with_migration, load_pref_with, save_app_state_with, save_pref_with,
     AppStateEnvelope, AppStateStore, CapabilityStatus, ContentCache, ExplorerBackendStatus,
@@ -248,6 +248,23 @@ impl AppLifecycleEvent {
     }
 }
 
+impl AppCapability {
+    /// Returns the stable kebab-case token for this capability.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Window => "window",
+            Self::State => "state",
+            Self::Config => "config",
+            Self::Theme => "theme",
+            Self::Wallpaper => "wallpaper",
+            Self::Notifications => "notifications",
+            Self::Ipc => "ipc",
+            Self::ExternalUrl => "external-url",
+            Self::Commands => "commands",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// Typed IPC envelope delivered through runtime-managed app inbox channels.
 pub struct AppEvent {
@@ -293,6 +310,31 @@ impl AppEvent {
         self.correlation_id = correlation_id;
         self.reply_to = reply_to;
         self
+    }
+
+    /// Creates a stable capability-denied diagnostic event delivered back to the source window.
+    pub fn capability_denied(
+        app_id: impl Into<String>,
+        capability: AppCapability,
+        window_id: WindowRuntimeId,
+        command: impl Into<String>,
+    ) -> Self {
+        let app_id = app_id.into();
+        Self {
+            schema_version: 1,
+            topic: "system.shell.capability-denied.v1".to_string(),
+            payload: serde_json::json!({
+                "app_id": app_id,
+                "capability": capability.as_str(),
+                "window_id": window_id,
+                "command": command.into(),
+            }),
+            correlation_id: None,
+            reply_to: None,
+            source_app_id: Some(app_id),
+            source_window_id: Some(window_id),
+            timestamp_unix_ms: None,
+        }
     }
 }
 
@@ -467,10 +509,12 @@ impl WindowService {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 /// State persistence service for window and app-shared state channels.
 pub struct StateService {
     sender: Callback<AppCommand>,
+    app_id: ApplicationId,
+    shared_state: ReadSignal<BTreeMap<String, Value>>,
 }
 
 impl StateService {
@@ -485,6 +529,12 @@ impl StateService {
             key: key.into(),
             state,
         });
+    }
+
+    /// Loads app-shared state previously persisted under `key`.
+    pub fn load_shared_state(&self, key: &str) -> Option<Value> {
+        let storage_key = format!("{}:{}", self.app_id.as_str(), key.trim());
+        self.shared_state.get().get(&storage_key).cloned()
     }
 }
 
@@ -1233,12 +1283,14 @@ impl AppServices {
     /// Creates service handles from the runtime command callback and host-selected adapters.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        app_id: ApplicationId,
         sender: Callback<AppCommand>,
         capabilities: CapabilitySet,
         app_state: Rc<dyn AppStateStore>,
         prefs: Rc<dyn PrefsStore>,
         explorer: Rc<dyn ExplorerFsService>,
         cache: Rc<dyn ContentCache>,
+        shared_state: ReadSignal<BTreeMap<String, Value>>,
         theme_high_contrast: ReadSignal<bool>,
         theme_reduced_motion: ReadSignal<bool>,
         wallpaper_current: ReadSignal<WallpaperConfig>,
@@ -1250,7 +1302,11 @@ impl AppServices {
         Self {
             capabilities,
             window: WindowService { sender },
-            state: StateService { sender },
+            state: StateService {
+                sender,
+                app_id,
+                shared_state,
+            },
             config: ConfigService {
                 sender,
                 prefs: prefs.clone(),
@@ -1355,6 +1411,8 @@ pub struct AppRegistration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leptos::{create_runtime, create_rw_signal};
+    use std::collections::BTreeMap;
 
     #[test]
     fn application_id_requires_dotted_namespaces() {
@@ -1400,5 +1458,51 @@ mod tests {
     #[test]
     fn primary_input_dom_id_uses_window_id() {
         assert_eq!(window_primary_input_dom_id(42), "window-primary-input-42");
+    }
+
+    #[test]
+    fn state_service_loads_shared_state_for_current_app() {
+        let runtime = create_runtime();
+        let sender = Callback::new(|_: AppCommand| {});
+        let shared_state = create_rw_signal(BTreeMap::from([(
+            "system.settings:appearance".to_string(),
+            serde_json::json!({ "tab": "wallpaper" }),
+        )]));
+        let service = StateService {
+            sender,
+            app_id: ApplicationId::trusted("system.settings"),
+            shared_state: shared_state.read_only(),
+        };
+
+        assert_eq!(
+            service.load_shared_state("appearance"),
+            Some(serde_json::json!({ "tab": "wallpaper" }))
+        );
+        assert_eq!(service.load_shared_state("missing"), None);
+
+        runtime.dispose();
+    }
+
+    #[test]
+    fn capability_denied_event_uses_stable_topic_and_payload() {
+        let event = AppEvent::capability_denied(
+            "system.terminal",
+            AppCapability::ExternalUrl,
+            7,
+            "open-external-url",
+        );
+
+        assert_eq!(event.topic, "system.shell.capability-denied.v1");
+        assert_eq!(event.source_app_id.as_deref(), Some("system.terminal"));
+        assert_eq!(event.source_window_id, Some(7));
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "app_id": "system.terminal",
+                "capability": "external-url",
+                "window_id": 7,
+                "command": "open-external-url",
+            })
+        );
     }
 }

--- a/ui/crates/desktop_runtime/src/apps.rs
+++ b/ui/crates/desktop_runtime/src/apps.rs
@@ -2,7 +2,7 @@
 
 use std::sync::OnceLock;
 
-use crate::model::{OpenWindowRequest, DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH};
+use crate::model::{DesktopState, OpenWindowRequest, DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH};
 use desktop_app_contract::{
     AppCapability, AppModule, AppMountContext, ApplicationId, SuspendPolicy,
 };
@@ -15,6 +15,17 @@ use system_ui::primitives::IconName;
 const APP_ID_CONTROL_CENTER: &str = "system.control-center";
 const APP_ID_TERMINAL: &str = "system.terminal";
 const APP_ID_SETTINGS: &str = "system.settings";
+const ALL_APP_CAPABILITIES: &[AppCapability] = &[
+    AppCapability::Window,
+    AppCapability::State,
+    AppCapability::Config,
+    AppCapability::Theme,
+    AppCapability::Wallpaper,
+    AppCapability::Notifications,
+    AppCapability::Ipc,
+    AppCapability::ExternalUrl,
+    AppCapability::Commands,
+];
 
 #[derive(Debug, Clone, Copy)]
 struct GeneratedAppManifestMetadata {
@@ -172,6 +183,20 @@ pub fn app_is_privileged_by_id(app_id: &ApplicationId) -> bool {
     BUILTIN_PRIVILEGED_APP_IDS
         .iter()
         .any(|id| *id == app_id.as_str())
+}
+
+/// Returns whether `app_id` is privileged after applying the current runtime policy overlay.
+pub fn app_is_privileged(state: &DesktopState, app_id: &ApplicationId) -> bool {
+    app_is_privileged_by_id(app_id) || state.privileged_app_ids.contains(app_id.as_str())
+}
+
+/// Returns the runtime-effective capabilities for an app after applying privilege policy.
+pub fn resolved_capabilities(state: &DesktopState, app_id: &ApplicationId) -> Vec<AppCapability> {
+    if app_is_privileged(state, app_id) {
+        ALL_APP_CAPABILITIES.to_vec()
+    } else {
+        app_requested_capabilities_by_id(app_id).to_vec()
+    }
 }
 
 /// Parses a canonical or legacy serialized app id into an [`ApplicationId`].

--- a/ui/crates/desktop_runtime/src/components/window.rs
+++ b/ui/crates/desktop_runtime/src/components/window.rs
@@ -314,6 +314,7 @@ fn ManagedWindowBody(window_id: WindowId) -> impl IntoView {
     let wallpaper_preview = create_rw_signal(runtime.state.get_untracked().wallpaper_preview);
     let wallpaper_library = create_rw_signal(runtime.state.get_untracked().wallpaper_library);
     let terminal_history = create_rw_signal(runtime.state.get_untracked().terminal_history);
+    let shared_state = create_rw_signal(runtime.state.get_untracked().app_shared_state);
     create_effect(move |_| {
         let desktop = runtime.state.get();
         theme_high_contrast.set(desktop.theme.high_contrast);
@@ -322,6 +323,7 @@ fn ManagedWindowBody(window_id: WindowId) -> impl IntoView {
         wallpaper_preview.set(desktop.wallpaper_preview);
         wallpaper_library.set(desktop.wallpaper_library);
         terminal_history.set(desktop.terminal_history);
+        shared_state.set(desktop.app_shared_state);
     });
     let command_sender = Callback::new(move |command| {
         spawn_local(async move {
@@ -336,9 +338,17 @@ fn ManagedWindowBody(window_id: WindowId) -> impl IntoView {
         .map(|w| w.app_id.clone())
         .expect("window app id");
     let capabilities = create_rw_signal(CapabilitySet::new(
-        apps::app_requested_capabilities_by_id(&app_id).to_vec(),
+        apps::resolved_capabilities(&state.get_untracked(), &app_id),
         runtime.host.get_value().host_capabilities(),
     ));
+    let capability_app_id = app_id.clone();
+    create_effect(move |_| {
+        let desktop = state.get();
+        capabilities.set(CapabilitySet::new(
+            apps::resolved_capabilities(&desktop, &capability_app_id),
+            runtime.host.get_value().host_capabilities(),
+        ));
+    });
     let platform_dashboard = create_rw_signal(
         InstitutionalPlatformClientV1 {
             client_name: "origin-shell".to_string(),
@@ -360,12 +370,14 @@ fn ManagedWindowBody(window_id: WindowId) -> impl IntoView {
         ),
     );
     let services = store_value(AppServices::new(
+        app_id.clone(),
         command_sender,
         capabilities.get_untracked(),
         runtime.host.get_value().app_state_store(),
         runtime.host.get_value().prefs_store(),
         runtime.host.get_value().explorer_fs_service(),
         runtime.host.get_value().content_cache(),
+        shared_state.read_only(),
         theme_high_contrast.read_only(),
         theme_reduced_motion.read_only(),
         wallpaper_current.read_only(),

--- a/ui/crates/desktop_runtime/src/host/boot.rs
+++ b/ui/crates/desktop_runtime/src/host/boot.rs
@@ -13,8 +13,24 @@ pub(super) fn install_boot_hydration(host: DesktopHostContext, dispatch: Callbac
 
             if !browser_e2e_active {
                 let legacy_snapshot = persistence::load_boot_snapshot(&boot_host).await;
-                if let Some(snapshot) = legacy_snapshot.clone() {
-                    dispatch.call(DesktopAction::HydrateSnapshot { snapshot });
+                let durable_snapshot = persistence::load_durable_boot_snapshot(&boot_host).await;
+                let restore_preferences = persistence::resolve_restore_preferences(
+                    durable_snapshot.as_ref(),
+                    legacy_snapshot.as_ref(),
+                );
+
+                if let Some(policy) = persistence::load_app_policy_overlay(&boot_host).await {
+                    dispatch.call(DesktopAction::HydratePolicyOverlay {
+                        privileged_app_ids: policy.privileged_app_ids,
+                    });
+                }
+                if restore_preferences.restore_on_boot {
+                    if let Some(snapshot) = legacy_snapshot.clone() {
+                        dispatch.call(DesktopAction::HydrateSnapshot {
+                            snapshot,
+                            mode: crate::reducer::HydrationMode::BootRestore,
+                        });
+                    }
                 }
 
                 if let Some(theme) = persistence::load_theme(&boot_host).await {
@@ -25,8 +41,13 @@ pub(super) fn install_boot_hydration(host: DesktopHostContext, dispatch: Callbac
                     dispatch.call(DesktopAction::HydrateWallpaper { wallpaper });
                 }
 
-                if let Some(snapshot) = persistence::load_durable_boot_snapshot(&boot_host).await {
-                    dispatch.call(DesktopAction::HydrateSnapshot { snapshot });
+                if restore_preferences.restore_on_boot {
+                    if let Some(snapshot) = durable_snapshot.clone() {
+                        dispatch.call(DesktopAction::HydrateSnapshot {
+                            snapshot,
+                            mode: crate::reducer::HydrationMode::BootRestore,
+                        });
+                    }
                 } else if let Some(snapshot) = legacy_snapshot.clone() {
                     let migrated_state = crate::model::DesktopState::from_snapshot(snapshot);
                     if let Err(err) =

--- a/ui/crates/desktop_runtime/src/lib.rs
+++ b/ui/crates/desktop_runtime/src/lib.rs
@@ -90,6 +90,6 @@ pub use platform_host::{
     WallpaperMediaKind, WallpaperPosition, WallpaperSelection, WallpaperSourceKind,
 };
 /// Re-exported reducer entrypoint and core action/effect enums.
-pub use reducer::{reduce_desktop, DesktopAction, RuntimeEffect};
+pub use reducer::{reduce_desktop, DesktopAction, HydrationMode, RuntimeEffect};
 /// Re-exported shared UI primitives for runtime-owned shell surfaces.
 pub use system_ui::prelude::{Icon, IconName, IconSize};

--- a/ui/crates/desktop_runtime/src/model.rs
+++ b/ui/crates/desktop_runtime/src/model.rs
@@ -1,6 +1,6 @@
 //! Core runtime data model, window geometry, persistence snapshots, and deep-link types.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use desktop_app_contract::ApplicationId;
 use platform_host::{WallpaperConfig, WallpaperLibrarySnapshot};
@@ -141,7 +141,7 @@ pub struct WindowRecord {
     /// Launch parameters provided to the app component.
     pub launch_params: Value,
     /// Last lifecycle token observed for this window.
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     pub last_lifecycle_event: Option<String>,
 }
 
@@ -157,13 +157,6 @@ pub struct DesktopTheme {
     /// Whether reduced motion rendering is enabled.
     #[serde(default)]
     pub reduced_motion: bool,
-    /// Whether desktop sound effects are enabled.
-    #[serde(default = "default_audio_enabled")]
-    pub audio_enabled: bool,
-}
-
-const fn default_audio_enabled() -> bool {
-    true
 }
 
 /// Current committed desktop wallpaper configuration.
@@ -211,10 +204,6 @@ pub struct DesktopState {
     pub wallpaper_library: WallpaperLibrarySnapshot,
     /// Runtime/user preferences.
     pub preferences: DesktopPreferences,
-    /// Last explorer path used by shell shortcuts/workflows.
-    pub last_explorer_path: Option<String>,
-    /// Last notepad slug used by shell shortcuts/workflows.
-    pub last_notepad_slug: Option<String>,
     /// Recent terminal commands captured for history.
     pub terminal_history: Vec<String>,
     /// App-shared state payloads keyed by `<app_id>:<key>`.
@@ -223,6 +212,9 @@ pub struct DesktopState {
     /// Whether asynchronous boot hydration has completed for the current runtime session.
     #[serde(skip)]
     pub boot_hydrated: bool,
+    /// App ids elevated by the runtime policy overlay for this session.
+    #[serde(skip)]
+    pub privileged_app_ids: BTreeSet<String>,
 }
 
 impl Default for DesktopState {
@@ -239,11 +231,10 @@ impl Default for DesktopState {
                 &WallpaperLibrarySnapshot::default(),
             ),
             preferences: DesktopPreferences::default(),
-            last_explorer_path: None,
-            last_notepad_slug: None,
             terminal_history: Vec::new(),
             app_shared_state: BTreeMap::new(),
             boot_hydrated: false,
+            privileged_app_ids: BTreeSet::new(),
         }
     }
 }
@@ -260,8 +251,6 @@ impl DesktopState {
             schema_version: DESKTOP_LAYOUT_SCHEMA_VERSION,
             preferences: self.preferences.clone(),
             windows: self.windows.clone(),
-            last_explorer_path: self.last_explorer_path.clone(),
-            last_notepad_slug: self.last_notepad_slug.clone(),
             terminal_history: self.terminal_history.clone(),
             app_shared_state: self.app_shared_state.clone(),
         }
@@ -274,8 +263,6 @@ impl DesktopState {
         let mut state = Self::default();
         state.preferences = snapshot.preferences;
         state.windows = snapshot.windows;
-        state.last_explorer_path = snapshot.last_explorer_path;
-        state.last_notepad_slug = snapshot.last_notepad_slug;
         state.terminal_history = snapshot.terminal_history;
         state.app_shared_state = snapshot.app_shared_state;
         state.boot_hydrated = false;
@@ -299,10 +286,6 @@ pub struct DesktopSnapshot {
     pub preferences: DesktopPreferences,
     /// Persisted open window records.
     pub windows: Vec<WindowRecord>,
-    /// Persisted explorer path hint.
-    pub last_explorer_path: Option<String>,
-    /// Persisted notepad slug hint.
-    pub last_notepad_slug: Option<String>,
     /// Persisted terminal history lines.
     pub terminal_history: Vec<String>,
     /// Persisted app-shared state payloads.
@@ -435,9 +418,9 @@ pub struct InteractionState {
 pub enum DeepLinkOpenTarget {
     /// Open an app by id.
     App(ApplicationId),
-    /// Open a notepad window for a note slug.
+    /// Open the shell's note-focused compatibility route for a note slug.
     NotesSlug(String),
-    /// Open an explorer window scoped to a project slug.
+    /// Open the shell's project-focused compatibility route for a project slug.
     ProjectSlug(String),
 }
 
@@ -514,12 +497,10 @@ mod tests {
         let theme = DesktopTheme {
             high_contrast: false,
             reduced_motion: true,
-            audio_enabled: true,
         };
         let encoded = serde_json::to_value(&theme).expect("serialize theme");
         let decoded: DesktopTheme = serde_json::from_value(encoded).expect("deserialize theme");
         assert!(decoded.reduced_motion);
-        assert!(decoded.audio_enabled);
     }
 
     #[test]
@@ -565,13 +546,50 @@ mod tests {
                     last_lifecycle_event: Some("focused".to_string()),
                 },
             ],
-            last_explorer_path: None,
-            last_notepad_slug: None,
             terminal_history: Vec::new(),
             app_shared_state: BTreeMap::new(),
         });
 
         assert_eq!(state.next_window_id, 12);
         assert_eq!(state.focused_window_id(), Some(WindowId(11)));
+    }
+
+    #[test]
+    fn snapshot_omits_runtime_only_lifecycle_marker() {
+        let snapshot = DesktopState::from_snapshot(DesktopSnapshot {
+            schema_version: DESKTOP_LAYOUT_SCHEMA_VERSION,
+            preferences: DesktopPreferences::default(),
+            windows: vec![WindowRecord {
+                id: WindowId(1),
+                app_id: ApplicationId::trusted("system.settings"),
+                title: "Settings".to_string(),
+                icon_id: "settings".to_string(),
+                rect: WindowRect::default(),
+                restore_rect: None,
+                z_index: 1,
+                is_focused: true,
+                minimized: false,
+                maximized: false,
+                suspended: false,
+                flags: WindowFlags::default(),
+                persist_key: None,
+                app_state: Value::Null,
+                launch_params: Value::Null,
+                last_lifecycle_event: Some("focused".to_string()),
+            }],
+            terminal_history: Vec::new(),
+            app_shared_state: BTreeMap::new(),
+        })
+        .snapshot();
+
+        let encoded = serde_json::to_value(snapshot).expect("serialize snapshot");
+        let windows = encoded
+            .get("windows")
+            .and_then(Value::as_array)
+            .expect("windows array");
+        assert!(
+            windows[0].get("last_lifecycle_event").is_none(),
+            "snapshot should not persist runtime lifecycle markers"
+        );
     }
 }

--- a/ui/crates/desktop_runtime/src/persistence.rs
+++ b/ui/crates/desktop_runtime/src/persistence.rs
@@ -1,7 +1,7 @@
 //! Desktop runtime persistence adapters for boot hydration and lightweight local preferences.
 
 use crate::host::DesktopHostContext;
-use crate::model::{DesktopSnapshot, DesktopState, DesktopTheme};
+use crate::model::{DesktopPreferences, DesktopSnapshot, DesktopState, DesktopTheme};
 #[cfg(test)]
 use platform_host::build_app_state_envelope;
 use platform_host::{
@@ -40,8 +40,6 @@ struct LegacyDesktopSnapshotV1 {
     theme: LegacyThemePayload,
     preferences: crate::model::DesktopPreferences,
     windows: Vec<crate::model::WindowRecord>,
-    last_explorer_path: Option<String>,
-    last_notepad_slug: Option<String>,
     terminal_history: Vec<String>,
     #[serde(default)]
     app_shared_state: std::collections::BTreeMap<String, serde_json::Value>,
@@ -59,8 +57,6 @@ fn migrate_desktop_snapshot(
                 schema_version: crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION,
                 preferences: legacy.preferences,
                 windows: legacy.windows,
-                last_explorer_path: legacy.last_explorer_path,
-                last_notepad_slug: legacy.last_notepad_slug,
                 terminal_history: legacy.terminal_history,
                 app_shared_state: legacy.app_shared_state,
             }))
@@ -103,8 +99,6 @@ pub async fn load_boot_snapshot(_host: &DesktopHostContext) -> Option<DesktopSna
                 schema_version: crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION,
                 preferences: Default::default(),
                 windows: Vec::new(),
-                last_explorer_path: None,
-                last_notepad_slug: None,
                 terminal_history: history,
                 app_shared_state: Default::default(),
             }),
@@ -135,6 +129,17 @@ pub async fn load_durable_boot_snapshot(host: &DesktopHostContext) -> Option<Des
             None
         }
     }
+}
+
+/// Resolves restore preferences from the most authoritative available snapshot.
+pub fn resolve_restore_preferences(
+    durable_snapshot: Option<&DesktopSnapshot>,
+    legacy_snapshot: Option<&DesktopSnapshot>,
+) -> DesktopPreferences {
+    durable_snapshot
+        .or(legacy_snapshot)
+        .map(|snapshot| snapshot.preferences.clone())
+        .unwrap_or_default()
 }
 
 /// Persists a durable desktop layout snapshot through the configured
@@ -187,7 +192,6 @@ pub async fn load_theme(host: &DesktopHostContext) -> Option<DesktopTheme> {
         Ok(None) => load_legacy_theme(host).await.map(|legacy| DesktopTheme {
             high_contrast: legacy.high_contrast,
             reduced_motion: legacy.reduced_motion,
-            audio_enabled: legacy.audio_enabled,
         }),
         Err(err) => {
             leptos::logging::warn!("desktop theme load failed: {err}");
@@ -291,5 +295,22 @@ mod tests {
         let migrated =
             migrate_desktop_snapshot(0, &envelope).expect("schema-zero migration should succeed");
         assert!(migrated.is_some(), "expected migrated desktop snapshot");
+    }
+
+    #[test]
+    fn restore_preferences_prefer_durable_snapshot_then_legacy() {
+        let mut legacy = DesktopState::default().snapshot();
+        legacy.preferences.restore_on_boot = false;
+
+        let mut durable = DesktopState::default().snapshot();
+        durable.preferences.restore_on_boot = true;
+        durable.preferences.max_restore_windows = 2;
+
+        let resolved = resolve_restore_preferences(Some(&durable), Some(&legacy));
+        assert!(resolved.restore_on_boot);
+        assert_eq!(resolved.max_restore_windows, 2);
+
+        let legacy_only = resolve_restore_preferences(None, Some(&legacy));
+        assert!(!legacy_only.restore_on_boot);
     }
 }

--- a/ui/crates/desktop_runtime/src/reducer.rs
+++ b/ui/crates/desktop_runtime/src/reducer.rs
@@ -212,6 +212,13 @@ pub enum DesktopAction {
     HydrateSnapshot {
         /// Snapshot payload to restore.
         snapshot: DesktopSnapshot,
+        /// Hydration intent controlling lifecycle replay.
+        mode: HydrationMode,
+    },
+    /// Hydrates the runtime policy overlay for the current session.
+    HydratePolicyOverlay {
+        /// App ids elevated by the policy overlay.
+        privileged_app_ids: Vec<String>,
     },
     /// Apply URL-derived deep-link instructions.
     ApplyDeepLink {
@@ -336,7 +343,16 @@ pub enum RuntimeEffect {
     },
 }
 
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Controls whether snapshot hydration is restoring boot state or synchronizing a live session.
+pub enum HydrationMode {
+    /// Restores a boot snapshot into an empty/new runtime session.
+    BootRestore,
+    /// Synchronizes persisted state into an already-running session.
+    SyncRefresh,
+}
+
+#[derive(Debug, Error, Clone, PartialEq)]
 /// Reducer errors for invalid actions (for example, referencing a missing window).
 pub enum ReducerError {
     /// The target window id was not found in the current state.
@@ -345,6 +361,24 @@ pub enum ReducerError {
     /// A wallpaper configuration violated runtime constraints.
     #[error("invalid wallpaper configuration: {0}")]
     InvalidWallpaperConfig(String),
+    /// The requested transition is blocked by an active modal window.
+    #[error("active modal window {active_modal:?} blocks this transition")]
+    ModalBlocked {
+        /// The modal window that must be resolved first.
+        active_modal: WindowId,
+    },
+    /// The app attempted to use a capability that is not granted.
+    #[error("app `{app_id}` is not authorized for capability `{capability:?}`")]
+    CapabilityDenied {
+        /// Canonical application identifier.
+        app_id: String,
+        /// The missing capability.
+        capability: AppCapability,
+        /// Source window receiving the denial diagnostic.
+        window_id: WindowId,
+        /// App-visible denial diagnostic envelope.
+        diagnostic_event: Box<AppEvent>,
+    },
 }
 
 fn clamp_window_rect_to_viewport(rect: WindowRect, viewport: WindowRect) -> WindowRect {
@@ -423,6 +457,7 @@ pub fn reduce_desktop(
         DesktopAction::OpenWindow(req) => {
             let previously_focused = state.focused_window_id();
             let window_id = next_window_id(state);
+            begin_modal_open(state, window_id, &req)?;
             let default_offset = ((window_id.0 as i32) - 1) % 8 * 20;
             let viewport = req.viewport.unwrap_or(WindowRect {
                 x: 0,
@@ -478,7 +513,9 @@ pub fn reduce_desktop(
             effects.push(RuntimeEffect::FocusWindowInput(window_id));
         }
         DesktopAction::CloseWindow { window_id } => {
+            ensure_parent_close_allowed(state, window_id)?;
             let was_focused = state.focused_window_id() == Some(window_id);
+            let modal_parent_to_focus = complete_modal_close(state, window_id);
             effects.push(RuntimeEffect::DispatchLifecycle {
                 window_id,
                 event: AppLifecycleEvent::Closing,
@@ -488,21 +525,24 @@ pub fn reduce_desktop(
             if state.windows.len() == before_len {
                 return Err(ReducerError::WindowNotFound);
             }
-            if state.active_modal == Some(window_id) {
-                state.active_modal = None;
-            }
             normalize_window_stack(state);
             effects.push(RuntimeEffect::DispatchLifecycle {
                 window_id,
                 event: AppLifecycleEvent::Closed,
             });
-            if was_focused {
+            if let Some(parent_id) = modal_parent_to_focus {
+                if focus_window_internal(state, parent_id) {
+                    emit_focus_transition(Some(window_id), Some(parent_id), state, &mut effects);
+                    effects.push(RuntimeEffect::FocusWindowInput(parent_id));
+                }
+            } else if was_focused {
                 let new_focus = state.focused_window_id();
                 emit_focus_transition(Some(window_id), new_focus, state, &mut effects);
             }
             effects.push(RuntimeEffect::PersistLayout);
         }
         DesktopAction::FocusWindow { window_id } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let previous_focus = state.focused_window_id();
             if !focus_window_internal(state, window_id) {
                 return Err(ReducerError::WindowNotFound);
@@ -512,6 +552,7 @@ pub fn reduce_desktop(
             effects.push(RuntimeEffect::FocusWindowInput(window_id));
         }
         DesktopAction::MinimizeWindow { window_id } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let previous_focus = state.focused_window_id();
             let should_suspend = {
                 let window = find_window_mut(state, window_id)?;
@@ -549,6 +590,7 @@ pub fn reduce_desktop(
             window_id,
             viewport,
         } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let previous_focus = state.focused_window_id();
             let was_suspended = {
                 let window = find_window_mut(state, window_id)?;
@@ -576,6 +618,7 @@ pub fn reduce_desktop(
             effects.push(RuntimeEffect::PersistLayout);
         }
         DesktopAction::RestoreWindow { window_id } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let previous_focus = state.focused_window_id();
             let was_suspended = {
                 let window = find_window_mut(state, window_id)?;
@@ -610,6 +653,7 @@ pub fn reduce_desktop(
             effects.push(RuntimeEffect::FocusWindowInput(window_id));
         }
         DesktopAction::ToggleTaskbarWindow { window_id } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let focused = state.focused_window_id() == Some(window_id);
             let minimized = state
                 .windows
@@ -644,6 +688,7 @@ pub fn reduce_desktop(
             state.start_menu_open = false;
         }
         DesktopAction::BeginMove { window_id, pointer } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let previous_focus = state.focused_window_id();
             let rect_start = find_window_mut(state, window_id)?.rect;
             if !focus_window_internal(state, window_id) {
@@ -689,6 +734,7 @@ pub fn reduce_desktop(
             pointer,
             viewport,
         } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let previous_focus = state.focused_window_id();
             let rect_start = find_window_mut(state, window_id)?.rect;
             if !focus_window_internal(state, window_id) {
@@ -720,6 +766,7 @@ pub fn reduce_desktop(
             effects.push(RuntimeEffect::PersistLayout);
         }
         DesktopAction::SuspendWindow { window_id } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let should_emit = {
                 let window = find_window_mut(state, window_id)?;
                 if window.suspended {
@@ -739,6 +786,7 @@ pub fn reduce_desktop(
             }
         }
         DesktopAction::ResumeWindow { window_id } => {
+            ensure_modal_allows_target(state, Some(window_id))?;
             let should_emit = {
                 let window = find_window_mut(state, window_id)?;
                 if window.suspended {
@@ -765,8 +813,18 @@ pub fn reduce_desktop(
                 .map(|w| w.app_id.clone())
                 .ok_or(ReducerError::WindowNotFound)?;
             if let Some(required) = command_required_capability(&command) {
-                if !command_allowed_for_app(&source_app_id, required) {
-                    return Ok(effects);
+                if !command_allowed_for_app(state, &source_app_id, required) {
+                    return Err(ReducerError::CapabilityDenied {
+                        app_id: source_app_id.to_string(),
+                        capability: required,
+                        window_id,
+                        diagnostic_event: Box::new(AppEvent::capability_denied(
+                            source_app_id.to_string(),
+                            required,
+                            window_id.0,
+                            command_label(&command),
+                        )),
+                    });
                 }
             }
 
@@ -986,38 +1044,42 @@ pub fn reduce_desktop(
             state.app_shared_state.insert(storage_key, shared);
             effects.push(RuntimeEffect::PersistLayout);
         }
-        DesktopAction::HydrateSnapshot { snapshot } => {
-            let max_restore = state.preferences.max_restore_windows;
+        DesktopAction::HydrateSnapshot { snapshot, mode } => {
             let theme = state.theme.clone();
             let wallpaper_config = state.wallpaper.clone();
             let wallpaper_preview = state.wallpaper_preview.clone();
             let wallpaper_library = state.wallpaper_library.clone();
+            let privileged_app_ids = state.privileged_app_ids.clone();
             *state = DesktopState::from_snapshot(snapshot);
             state.theme = theme;
             state.wallpaper = wallpaper_config;
             state.wallpaper_preview = wallpaper_preview;
             state.wallpaper_library = wallpaper_library;
+            state.privileged_app_ids = privileged_app_ids;
+            let max_restore = state.preferences.max_restore_windows;
             if state.windows.len() > max_restore {
                 state.windows.truncate(max_restore);
             }
             normalize_window_stack(state);
-            for window in state.windows.iter_mut() {
-                if window.last_lifecycle_event.is_none() {
-                    window.last_lifecycle_event =
-                        Some(AppLifecycleEvent::Mounted.token().to_string());
+            if matches!(mode, HydrationMode::BootRestore) {
+                for window in state.windows.iter_mut() {
+                    record_window_lifecycle_by_id(window, AppLifecycleEvent::Mounted);
+                    effects.push(RuntimeEffect::DispatchLifecycle {
+                        window_id: window.id,
+                        event: AppLifecycleEvent::Mounted,
+                    });
                 }
-                effects.push(RuntimeEffect::DispatchLifecycle {
-                    window_id: window.id,
-                    event: AppLifecycleEvent::Mounted,
-                });
+                if let Some(focused) = state.focused_window_id() {
+                    record_window_lifecycle(state, focused, AppLifecycleEvent::Focused);
+                    effects.push(RuntimeEffect::DispatchLifecycle {
+                        window_id: focused,
+                        event: AppLifecycleEvent::Focused,
+                    });
+                }
             }
-            if let Some(focused) = state.focused_window_id() {
-                record_window_lifecycle(state, focused, AppLifecycleEvent::Focused);
-                effects.push(RuntimeEffect::DispatchLifecycle {
-                    window_id: focused,
-                    event: AppLifecycleEvent::Focused,
-                });
-            }
+        }
+        DesktopAction::HydratePolicyOverlay { privileged_app_ids } => {
+            state.privileged_app_ids = privileged_app_ids.into_iter().collect();
         }
         DesktopAction::ApplyDeepLink { deep_link } => {
             effects.push(RuntimeEffect::ParseAndOpenDeepLink(deep_link));
@@ -1051,6 +1113,7 @@ pub fn build_open_request_from_deeplink(target: DeepLinkOpenTarget) -> OpenWindo
     match target {
         DeepLinkOpenTarget::App(app_id) => OpenWindowRequest::new(app_id),
         DeepLinkOpenTarget::NotesSlug(slug) => {
+            // Notes deep links remain a compatibility route into the Settings experience.
             let mut req = OpenWindowRequest::new(apps::settings_application_id());
             req.title = Some(format!("Settings - Notes {slug}"));
             req.persist_key = Some(format!("notes:{slug}"));
@@ -1058,6 +1121,7 @@ pub fn build_open_request_from_deeplink(target: DeepLinkOpenTarget) -> OpenWindo
             req
         }
         DeepLinkOpenTarget::ProjectSlug(slug) => {
+            // Project deep links remain a compatibility route into Control Center.
             let mut req = OpenWindowRequest::new(ApplicationId::trusted("system.control-center"));
             req.title = Some(format!("Project - {slug}"));
             req.persist_key = Some(format!("projects:{slug}"));
@@ -1107,8 +1171,12 @@ fn record_window_lifecycle(
     event: AppLifecycleEvent,
 ) {
     if let Some(window) = state.windows.iter_mut().find(|w| w.id == window_id) {
-        window.last_lifecycle_event = Some(event.token().to_string());
+        record_window_lifecycle_by_id(window, event);
     }
+}
+
+fn record_window_lifecycle_by_id(window: &mut WindowRecord, event: AppLifecycleEvent) {
+    window.last_lifecycle_event = Some(event.token().to_string());
 }
 
 fn emit_focus_transition(
@@ -1173,11 +1241,114 @@ fn command_required_capability(command: &AppCommand) -> Option<AppCapability> {
     }
 }
 
-fn command_allowed_for_app(app_id: &ApplicationId, required: AppCapability) -> bool {
-    if apps::app_is_privileged_by_id(app_id) {
-        return true;
+fn command_allowed_for_app(
+    state: &DesktopState,
+    app_id: &ApplicationId,
+    required: AppCapability,
+) -> bool {
+    apps::resolved_capabilities(state, app_id).contains(&required)
+}
+
+fn active_modal_window(state: &DesktopState) -> Option<&WindowRecord> {
+    let active_modal = state.active_modal?;
+    state
+        .windows
+        .iter()
+        .find(|window| window.id == active_modal)
+}
+
+fn begin_modal_open(
+    state: &mut DesktopState,
+    incoming_window_id: WindowId,
+    req: &OpenWindowRequest,
+) -> Result<(), ReducerError> {
+    let modal_parent = req.flags.modal_parent;
+    if let Some(active_modal) = active_modal_window(state) {
+        return Err(ReducerError::ModalBlocked {
+            active_modal: active_modal.id,
+        });
     }
-    apps::app_requested_capabilities_by_id(app_id).contains(&required)
+
+    if let Some(parent_id) = modal_parent {
+        if !state.windows.iter().any(|window| window.id == parent_id) {
+            return Err(ReducerError::WindowNotFound);
+        }
+        state.active_modal = Some(incoming_window_id);
+    }
+
+    Ok(())
+}
+
+fn ensure_modal_allows_target(
+    state: &DesktopState,
+    target_window_id: Option<WindowId>,
+) -> Result<(), ReducerError> {
+    let Some(active_modal) = active_modal_window(state) else {
+        return Ok(());
+    };
+    if Some(active_modal.id) == target_window_id {
+        return Ok(());
+    }
+
+    Err(ReducerError::ModalBlocked {
+        active_modal: active_modal.id,
+    })
+}
+
+fn complete_modal_close(state: &mut DesktopState, closed_window_id: WindowId) -> Option<WindowId> {
+    let active_modal = active_modal_window(state)?;
+    if active_modal.id != closed_window_id {
+        return None;
+    }
+
+    let parent_id = active_modal.flags.modal_parent;
+    state.active_modal = None;
+    parent_id.filter(|parent_id| state.windows.iter().any(|window| window.id == *parent_id))
+}
+
+fn ensure_parent_close_allowed(
+    state: &DesktopState,
+    parent_window_id: WindowId,
+) -> Result<(), ReducerError> {
+    let Some(active_modal) = active_modal_window(state) else {
+        return Ok(());
+    };
+    if active_modal.flags.modal_parent == Some(parent_window_id) {
+        return Err(ReducerError::ModalBlocked {
+            active_modal: active_modal.id,
+        });
+    }
+
+    Ok(())
+}
+
+fn command_label(command: &AppCommand) -> &'static str {
+    match command {
+        AppCommand::SetWindowTitle { .. } => "set-window-title",
+        AppCommand::PersistState { .. } => "persist-state",
+        AppCommand::PersistSharedState { .. } => "persist-shared-state",
+        AppCommand::SaveConfig { .. } => "save-config",
+        AppCommand::OpenExternalUrl { .. } => "open-external-url",
+        AppCommand::Subscribe { .. } => "subscribe",
+        AppCommand::Unsubscribe { .. } => "unsubscribe",
+        AppCommand::PublishEvent { .. } => "publish-event",
+        AppCommand::PreviewWallpaper { .. } => "preview-wallpaper",
+        AppCommand::ApplyWallpaperPreview => "apply-wallpaper-preview",
+        AppCommand::SetCurrentWallpaper { .. } => "set-current-wallpaper",
+        AppCommand::ClearWallpaperPreview => "clear-wallpaper-preview",
+        AppCommand::ImportWallpaperFromPicker { .. } => "import-wallpaper-from-picker",
+        AppCommand::RenameWallpaperAsset { .. } => "rename-wallpaper-asset",
+        AppCommand::SetWallpaperFavorite { .. } => "set-wallpaper-favorite",
+        AppCommand::SetWallpaperTags { .. } => "set-wallpaper-tags",
+        AppCommand::SetWallpaperCollections { .. } => "set-wallpaper-collections",
+        AppCommand::CreateWallpaperCollection { .. } => "create-wallpaper-collection",
+        AppCommand::RenameWallpaperCollection { .. } => "rename-wallpaper-collection",
+        AppCommand::DeleteWallpaperCollection { .. } => "delete-wallpaper-collection",
+        AppCommand::DeleteWallpaperAsset { .. } => "delete-wallpaper-asset",
+        AppCommand::SetDesktopHighContrast { .. } => "set-desktop-high-contrast",
+        AppCommand::SetDesktopReducedMotion { .. } => "set-desktop-reduced-motion",
+        AppCommand::Notify { .. } => "notify",
+    }
 }
 
 #[cfg(test)]
@@ -1185,7 +1356,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::model::{InteractionState, OpenWindowRequest};
+    use crate::model::{InteractionState, OpenWindowRequest, WindowFlags};
     use desktop_app_contract::ApplicationId;
     use platform_host::{WallpaperDisplayMode, WallpaperSelection};
 
@@ -1826,6 +1997,425 @@ mod tests {
                 correlation_id: None,
                 reply_to: None,
             }]
+        );
+    }
+
+    #[test]
+    fn hydrate_snapshot_uses_restored_restore_limit() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let mut snapshot = DesktopState::default().snapshot();
+        snapshot.preferences.max_restore_windows = 1;
+        snapshot.windows = vec![
+            WindowRecord {
+                id: WindowId(1),
+                app_id: ApplicationId::trusted("system.control-center"),
+                title: "Control Center".to_string(),
+                icon_id: "home".to_string(),
+                rect: WindowRect::default(),
+                restore_rect: None,
+                z_index: 1,
+                is_focused: true,
+                minimized: false,
+                maximized: false,
+                suspended: false,
+                flags: WindowFlags::default(),
+                persist_key: None,
+                app_state: Value::Null,
+                launch_params: Value::Null,
+                last_lifecycle_event: None,
+            },
+            WindowRecord {
+                id: WindowId(2),
+                app_id: ApplicationId::trusted("system.settings"),
+                title: "Settings".to_string(),
+                icon_id: "settings".to_string(),
+                rect: WindowRect::default(),
+                restore_rect: None,
+                z_index: 2,
+                is_focused: false,
+                minimized: false,
+                maximized: false,
+                suspended: false,
+                flags: WindowFlags::default(),
+                persist_key: None,
+                app_state: Value::Null,
+                launch_params: Value::Null,
+                last_lifecycle_event: None,
+            },
+        ];
+        state.preferences.max_restore_windows = 5;
+
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::HydrateSnapshot {
+                snapshot,
+                mode: HydrationMode::BootRestore,
+            },
+        )
+        .expect("hydrate snapshot");
+
+        assert_eq!(state.windows.len(), 1);
+        assert_eq!(state.windows[0].id, WindowId(1));
+    }
+
+    #[test]
+    fn sync_hydration_does_not_replay_mount_lifecycle_effects() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let mut snapshot = DesktopState::default().snapshot();
+        snapshot.windows = vec![WindowRecord {
+            id: WindowId(1),
+            app_id: ApplicationId::trusted("system.control-center"),
+            title: "Control Center".to_string(),
+            icon_id: "home".to_string(),
+            rect: WindowRect::default(),
+            restore_rect: None,
+            z_index: 1,
+            is_focused: true,
+            minimized: false,
+            maximized: false,
+            suspended: false,
+            flags: WindowFlags::default(),
+            persist_key: None,
+            app_state: Value::Null,
+            launch_params: Value::Null,
+            last_lifecycle_event: Some(AppLifecycleEvent::Focused.token().to_string()),
+        }];
+
+        let effects = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::HydrateSnapshot {
+                snapshot,
+                mode: HydrationMode::SyncRefresh,
+            },
+        )
+        .expect("sync hydrate");
+
+        assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn active_modal_blocks_non_modal_focus_transitions() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let parent = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.settings"),
+        );
+        let other = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.control-center"),
+        );
+        let mut modal_request = OpenWindowRequest::new(ApplicationId::trusted("system.settings"));
+        modal_request.flags.modal_parent = Some(parent);
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(modal_request),
+        )
+        .expect("open modal");
+        let modal_id = state.windows.last().expect("modal window").id;
+        assert_eq!(state.active_modal, Some(modal_id));
+
+        let err = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::FocusWindow { window_id: other },
+        )
+        .expect_err("modal should block focus");
+        assert!(matches!(
+            err,
+            ReducerError::ModalBlocked { active_modal } if active_modal == modal_id
+        ));
+    }
+
+    #[test]
+    fn opening_modal_child_sets_active_modal() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let parent = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.settings"),
+        );
+        let mut modal_request = OpenWindowRequest::new(ApplicationId::trusted("system.settings"));
+        modal_request.flags.modal_parent = Some(parent);
+
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(modal_request),
+        )
+        .expect("open modal child");
+
+        let modal = state.windows.last().expect("modal window");
+        assert_eq!(state.active_modal, Some(modal.id));
+        assert_eq!(modal.flags.modal_parent, Some(parent));
+        assert_eq!(state.focused_window_id(), Some(modal.id));
+    }
+
+    #[test]
+    fn active_modal_blocks_new_non_modal_window_opens() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let parent = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.settings"),
+        );
+        let mut modal_request = OpenWindowRequest::new(ApplicationId::trusted("system.settings"));
+        modal_request.flags.modal_parent = Some(parent);
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(modal_request),
+        )
+        .expect("open modal");
+        let modal_id = state.active_modal.expect("active modal");
+
+        let err = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(OpenWindowRequest::new(ApplicationId::trusted(
+                "system.control-center",
+            ))),
+        )
+        .expect_err("modal should block unrelated open");
+
+        assert!(matches!(
+            err,
+            ReducerError::ModalBlocked { active_modal } if active_modal == modal_id
+        ));
+    }
+
+    #[test]
+    fn active_modal_blocks_new_modal_window_opens() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let parent = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.settings"),
+        );
+        let mut first_modal = OpenWindowRequest::new(ApplicationId::trusted("system.settings"));
+        first_modal.flags.modal_parent = Some(parent);
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(first_modal),
+        )
+        .expect("open first modal");
+        let active_modal = state.active_modal.expect("active modal");
+
+        let mut second_modal = OpenWindowRequest::new(ApplicationId::trusted("system.settings"));
+        second_modal.flags.modal_parent = Some(parent);
+        let err = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(second_modal),
+        )
+        .expect_err("active modal should block second modal");
+
+        assert!(matches!(
+            err,
+            ReducerError::ModalBlocked { active_modal: blocked } if blocked == active_modal
+        ));
+    }
+
+    #[test]
+    fn closing_active_modal_clears_active_modal_and_focuses_parent() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let parent = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.settings"),
+        );
+        let mut modal_request = OpenWindowRequest::new(ApplicationId::trusted("system.settings"));
+        modal_request.flags.modal_parent = Some(parent);
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(modal_request),
+        )
+        .expect("open modal");
+        let modal_id = state.active_modal.expect("active modal");
+
+        let effects = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::CloseWindow {
+                window_id: modal_id,
+            },
+        )
+        .expect("close modal");
+
+        assert!(state.active_modal.is_none());
+        assert_eq!(state.focused_window_id(), Some(parent));
+        assert!(!state.windows.iter().any(|window| window.id == modal_id));
+        assert!(effects.contains(&RuntimeEffect::FocusWindowInput(parent)));
+    }
+
+    #[test]
+    fn closing_modal_parent_while_child_is_active_is_rejected() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let parent = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.settings"),
+        );
+        let mut modal_request = OpenWindowRequest::new(ApplicationId::trusted("system.settings"));
+        modal_request.flags.modal_parent = Some(parent);
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::OpenWindow(modal_request),
+        )
+        .expect("open modal");
+        let modal_id = state.active_modal.expect("active modal");
+
+        let err = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::CloseWindow { window_id: parent },
+        )
+        .expect_err("modal parent close should be blocked");
+
+        assert!(matches!(
+            err,
+            ReducerError::ModalBlocked { active_modal } if active_modal == modal_id
+        ));
+    }
+
+    #[test]
+    fn policy_overlay_grants_privileged_command_access() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let terminal = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.terminal"),
+        );
+
+        let denied = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::HandleAppCommand {
+                window_id: terminal,
+                command: AppCommand::OpenExternalUrl {
+                    url: "https://example.com".to_string(),
+                },
+            },
+        )
+        .expect_err("terminal should not have external-url access by default");
+        assert!(matches!(denied, ReducerError::CapabilityDenied { .. }));
+
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::HydratePolicyOverlay {
+                privileged_app_ids: vec!["system.terminal".to_string()],
+            },
+        )
+        .expect("hydrate policy overlay");
+
+        let effects = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::HandleAppCommand {
+                window_id: terminal,
+                command: AppCommand::OpenExternalUrl {
+                    url: "https://example.com".to_string(),
+                },
+            },
+        )
+        .expect("overlay should authorize command");
+        assert_eq!(
+            effects,
+            vec![RuntimeEffect::OpenExternalUrl(
+                "https://example.com".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn capability_denial_returns_stable_diagnostic_event() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let terminal = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.terminal"),
+        );
+
+        let err = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::HandleAppCommand {
+                window_id: terminal,
+                command: AppCommand::OpenExternalUrl {
+                    url: "https://example.com".to_string(),
+                },
+            },
+        )
+        .expect_err("terminal should not have external-url access by default");
+
+        match err {
+            ReducerError::CapabilityDenied {
+                app_id,
+                capability,
+                window_id,
+                diagnostic_event,
+            } => {
+                assert_eq!(app_id, "system.terminal");
+                assert_eq!(capability, AppCapability::ExternalUrl);
+                assert_eq!(window_id, terminal);
+                assert_eq!(
+                    diagnostic_event,
+                    Box::new(AppEvent::capability_denied(
+                        "system.terminal",
+                        AppCapability::ExternalUrl,
+                        terminal.0,
+                        "open-external-url",
+                    ))
+                );
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn notes_deeplink_resolves_to_settings_compatibility_route() {
+        let request =
+            build_open_request_from_deeplink(DeepLinkOpenTarget::NotesSlug("roadmap".to_string()));
+
+        assert_eq!(request.app_id, apps::settings_application_id());
+        assert_eq!(request.persist_key.as_deref(), Some("notes:roadmap"));
+        assert_eq!(
+            request.launch_params,
+            json!({ "section": "personalize", "note_slug": "roadmap" })
+        );
+    }
+
+    #[test]
+    fn projects_deeplink_resolves_to_control_center_compatibility_route() {
+        let request =
+            build_open_request_from_deeplink(DeepLinkOpenTarget::ProjectSlug("alpha".to_string()));
+
+        assert_eq!(
+            request.app_id,
+            ApplicationId::trusted("system.control-center")
+        );
+        assert_eq!(request.persist_key.as_deref(), Some("projects:alpha"));
+        assert_eq!(
+            request.launch_params,
+            json!({ "section": "overview", "project_slug": "alpha" })
         );
     }
 }

--- a/ui/crates/desktop_runtime/src/runtime_context.rs
+++ b/ui/crates/desktop_runtime/src/runtime_context.rs
@@ -93,7 +93,22 @@ pub fn DesktopProvider(
                     effects.set(queue);
                 }
             }
-            Err(err) => logging::warn!("desktop reducer error: {err}"),
+            Err(err) => {
+                if let crate::reducer::ReducerError::CapabilityDenied {
+                    window_id,
+                    diagnostic_event,
+                    ..
+                } = &err
+                {
+                    let mut queue = effects.get_untracked();
+                    queue.push(RuntimeEffect::DeliverAppEvent {
+                        window_id: *window_id,
+                        event: diagnostic_event.as_ref().clone(),
+                    });
+                    effects.set(queue);
+                }
+                logging::warn!("desktop reducer error: {err}");
+            }
         }
     });
 

--- a/ui/crates/desktop_runtime/src/shell/policy.rs
+++ b/ui/crates/desktop_runtime/src/shell/policy.rs
@@ -4,6 +4,7 @@ use desktop_app_contract::{
     AppCapability, AppCommandContext, AppCommandRegistration, ApplicationId,
     CommandRegistrationHandle as AppCommandRegistrationHandle,
 };
+use leptos::SignalGetUntracked;
 use system_shell::CommandExecutionContext;
 use system_shell_contract::{
     CommandDescriptor, CommandNoticeLevel, CommandScope, ShellStreamEvent,
@@ -17,13 +18,13 @@ pub(super) fn register_app_command(
     window_id: WindowId,
     registration: AppCommandRegistration,
 ) -> Result<AppCommandRegistrationHandle, String> {
-    if !app_can_register_commands(&app_id) {
+    if !app_can_register_commands(runtime, &app_id) {
         return Err(format!(
             "{} is not allowed to register system commands",
             app_id.as_str()
         ));
     }
-    validate_scope(&registration.descriptor.scope, &app_id, window_id)?;
+    validate_scope(runtime, &registration.descriptor.scope, &app_id, window_id)?;
     let completion = registration.completion.clone();
     let handler = registration.handler.clone();
     let descriptor = registration.descriptor.clone();
@@ -75,18 +76,21 @@ fn emit_shell_event(context: &CommandExecutionContext, event: ShellStreamEvent) 
     }
 }
 
-fn app_can_register_commands(app_id: &ApplicationId) -> bool {
-    apps::app_is_privileged_by_id(app_id)
-        || apps::app_requested_capabilities_by_id(app_id).contains(&AppCapability::Commands)
+fn app_can_register_commands(runtime: DesktopRuntimeContext, app_id: &ApplicationId) -> bool {
+    let state = runtime.state.get_untracked();
+    apps::app_is_privileged(&state, app_id)
+        || apps::resolved_capabilities(&state, app_id).contains(&AppCapability::Commands)
 }
 
 fn validate_scope(
+    runtime: DesktopRuntimeContext,
     scope: &CommandScope,
     app_id: &ApplicationId,
     window_id: WindowId,
 ) -> Result<(), String> {
+    let state = runtime.state.get_untracked();
     match scope {
-        CommandScope::Global if apps::app_is_privileged_by_id(app_id) => Ok(()),
+        CommandScope::Global if apps::app_is_privileged(&state, app_id) => Ok(()),
         CommandScope::Global => {
             Err("only privileged apps may register global commands".to_string())
         }


### PR DESCRIPTION
## Summary
- rebase the runtime remediation work onto the hardened main line
- keep the scope to desktop runtime semantics and policy behavior
- preserve the Trunk/SRI hardening pipeline by excluding Trunk config, hardening verification, and service-worker release-path regressions

## Scope
- shared app service and capability-denial diagnostics
- runtime hydration, persistence, policy overlay, and modal behavior
- app persistence callback ownership fixes in shell apps

## Deferred to follow-up PRs
- browser shell interop glue
- preview smoke and dev-PWA hygiene checks

## Verification
- cargo fmt --all --check
- cargo check -p desktop_runtime -p desktop_app_contract
