### PR TITLE
fix(ui): split browser shell interop from runtime remediation

### DIFF
--- a/ui/crates/desktop_runtime/src/shell.rs
+++ b/ui/crates/desktop_runtime/src/shell.rs
@@ -507,6 +507,7 @@ fn resolve_open_target(target: &str) -> Option<DesktopAction> {
         });
     }
     if let Some(slug) = target.strip_prefix("notes:") {
+        // Notes remain a compatibility route into the shell's Settings-based experience.
         return Some(DesktopAction::OpenWindow(
             crate::reducer::build_open_request_from_deeplink(
                 crate::model::DeepLinkOpenTarget::NotesSlug(slug.to_string()),
@@ -514,6 +515,7 @@ fn resolve_open_target(target: &str) -> Option<DesktopAction> {
         ));
     }
     if let Some(slug) = target.strip_prefix("projects:") {
+        // Projects remain a compatibility route into the shell's Control Center experience.
         return Some(DesktopAction::OpenWindow(
             crate::reducer::build_open_request_from_deeplink(
                 crate::model::DeepLinkOpenTarget::ProjectSlug(slug.to_string()),
@@ -820,7 +822,8 @@ fn open_registration(runtime: DesktopRuntimeContext) -> AppCommandRegistration {
             "open <target>",
             vec![CommandArgSpec {
                 name: "target".to_string(),
-                summary: "Canonical app id or deep-link target such as notes:slug.".to_string(),
+                summary: "Canonical app id or compatibility deep-link target such as notes:slug."
+                    .to_string(),
                 required: true,
                 repeatable: false,
             }],

--- a/ui/crates/platform_host_web/src/bridge/interop/mod.rs
+++ b/ui/crates/platform_host_web/src/bridge/interop/mod.rs
@@ -103,3 +103,7 @@ pub async fn explorer_stat(path: &str) -> Result<ExplorerMetadata, String> {
 pub async fn open_external_url(url: &str) -> Result<(), String> {
     imp::open_external_url(url).await
 }
+
+pub async fn send_notification(title: &str, body: &str) -> Result<(), String> {
+    imp::send_notification(title, body).await
+}

--- a/ui/crates/platform_host_web/src/bridge/interop/non_wasm.rs
+++ b/ui/crates/platform_host_web/src/bridge/interop/non_wasm.rs
@@ -92,3 +92,7 @@ pub async fn explorer_stat(_path: &str) -> Result<ExplorerMetadata, String> {
 pub async fn open_external_url(_url: &str) -> Result<(), String> {
     Err(unsupported())
 }
+
+pub async fn send_notification(_title: &str, _body: &str) -> Result<(), String> {
+    Err(unsupported())
+}

--- a/ui/crates/platform_host_web/src/bridge/interop/wasm.rs
+++ b/ui/crates/platform_host_web/src/bridge/interop/wasm.rs
@@ -908,6 +908,13 @@ export async function jsOpenExternalUrl(url) {
   if (!opened) fail(`Failed to open external URL: ${url}`);
   return null;
 }
+export async function jsNotifySend(title, body) {
+  if (!title || typeof title !== 'string') fail('Notification title is required');
+  const tauri = await tauriInvoke('notify_send', { title, body: body || '' });
+  if (tauri.available) return tauri.value ?? null;
+  const rendered = !body || !String(body).trim() ? title : `${title}: ${body}`;
+  return await new Notification(rendered);
+}
 "#)]
 extern "C" {
     #[wasm_bindgen(js_name = jsAppStateLoad)]
@@ -956,6 +963,8 @@ extern "C" {
     fn js_explorer_clear_native_root() -> Promise;
     #[wasm_bindgen(js_name = jsOpenExternalUrl)]
     fn js_open_external_url(url: &str) -> Promise;
+    #[wasm_bindgen(js_name = jsNotifySend)]
+    fn js_notify_send(title: &str, body: &str) -> Promise;
 }
 
 async fn await_promise(promise: Promise) -> Result<JsValue, String> {
@@ -1109,5 +1118,10 @@ pub async fn explorer_clear_native_root() -> Result<ExplorerBackendStatus, Strin
 
 pub async fn open_external_url(url: &str) -> Result<(), String> {
     let _ = await_promise(js_open_external_url(url)).await?;
+    Ok(())
+}
+
+pub async fn send_notification(title: &str, body: &str) -> Result<(), String> {
+    let _ = await_promise(js_notify_send(title, body)).await?;
     Ok(())
 }

--- a/ui/crates/platform_host_web/src/bridge/mod.rs
+++ b/ui/crates/platform_host_web/src/bridge/mod.rs
@@ -100,6 +100,10 @@ pub async fn open_external_url(url: &str) -> Result<(), String> {
     interop::open_external_url(url).await
 }
 
+pub async fn send_notification(title: &str, body: &str) -> Result<(), String> {
+    interop::send_notification(title, body).await
+}
+
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;

--- a/ui/crates/platform_host_web/src/notifications.rs
+++ b/ui/crates/platform_host_web/src/notifications.rs
@@ -1,5 +1,6 @@
 //! Notification host-service adapters for browser and desktop-webview contexts.
 
+use crate::bridge;
 use platform_host::{NotificationFuture, NotificationService};
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -45,6 +46,6 @@ impl NotificationService for TauriNotificationService {
         title: &'a str,
         body: &'a str,
     ) -> NotificationFuture<'a, Result<(), String>> {
-        WebNotificationService.notify(title, body)
+        Box::pin(async move { bridge::send_notification(title, body).await })
     }
 }

--- a/ui/crates/site/src/web_app.rs
+++ b/ui/crates/site/src/web_app.rs
@@ -20,6 +20,14 @@ const DESKTOP_THEME_CSS: &str = concat!(
     include_str!("styles/a11y.css"),
 );
 
+fn note_shell_compatibility_href(slug: &str) -> String {
+    format!("/?open=notes:{slug}")
+}
+
+fn project_shell_compatibility_href(slug: &str) -> String {
+    format!("/?open=projects:{slug}")
+}
+
 #[component]
 /// Root application component that configures metadata, routes, and the desktop shell entrypoint.
 pub fn SiteApp() -> impl IntoView {
@@ -92,7 +100,9 @@ fn BrowserShellSync() -> impl IntoView {
 
     #[cfg(target_arch = "wasm32")]
     {
-        use desktop_runtime::{load_durable_boot_snapshot, load_theme, load_wallpaper};
+        use desktop_runtime::{
+            load_durable_boot_snapshot, load_theme, load_wallpaper, HydrationMode,
+        };
         use wasm_bindgen::{closure::Closure, JsCast};
 
         let host = _runtime.host.get_value();
@@ -141,6 +151,7 @@ fn BrowserShellSync() -> impl IntoView {
                                 if let Some(snapshot) = load_durable_boot_snapshot(&host).await {
                                     runtime.dispatch_action(DesktopAction::HydrateSnapshot {
                                         snapshot,
+                                        mode: HydrationMode::SyncRefresh,
                                     });
                                 }
                             });
@@ -176,8 +187,8 @@ fn CanonicalNoteRoute() -> impl IntoView {
         <section class="canonical-content canonical-note">
             <h1>"Note"</h1>
             <p>{move || format!("Slug: {}", slug())}</p>
-            <p>"Browser-native note route with shell compatibility open intents."</p>
-            <A href=move || format!("/?open=notes:{}", slug())>"Open in Shell"</A>
+            <p>"Browser-native note compatibility route that opens the shell's Settings-based compatibility route."</p>
+            <A href=move || note_shell_compatibility_href(&slug())>"Open in Shell"</A>
         </section>
     }
 }
@@ -195,8 +206,29 @@ fn CanonicalProjectRoute() -> impl IntoView {
         <section class="canonical-content canonical-project">
             <h1>"Project"</h1>
             <p>{move || format!("Slug: {}", slug())}</p>
-            <p>"Browser-native project route with shell compatibility open intents."</p>
-            <A href=move || format!("/?open=projects:{}", slug())>"Open in Shell"</A>
+            <p>"Browser-native project compatibility route that opens the shell's Control Center compatibility route."</p>
+            <A href=move || project_shell_compatibility_href(&slug())>"Open in Shell"</A>
         </section>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_shell_open_link_uses_compatibility_route() {
+        assert_eq!(
+            note_shell_compatibility_href("roadmap"),
+            "/?open=notes:roadmap"
+        );
+    }
+
+    #[test]
+    fn project_shell_open_link_uses_compatibility_route() {
+        assert_eq!(
+            project_shell_compatibility_href("alpha"),
+            "/?open=projects:alpha"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- split browser shell interop updates out of the runtime remediation branch
- keep this PR stacked on top of #54 because it depends on the rebased HydrationMode/runtime contract
- preserve the hardened Trunk/SRI pipeline by leaving Trunk config, hardening verification, and release-path service-worker behavior unchanged

## Scope
- browser notification bridge plumbing
- browser shell sync hydration mode updates
- compatibility route copy for notes/projects shell entrypoints

## Verification
- cargo fmt --all --check
- cargo check -p site --target wasm32-unknown-unknown --features csr
