### PR TITLE
fix(ui): add preview smoke and browser hygiene checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7106,6 +7106,7 @@ dependencies = [
  "leptos_router",
  "platform_host_web",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -66,14 +66,13 @@ Run from the repository root:
 ```bash
 cargo ui-dev
 cargo ui-build
-cargo ui-harden
+cargo verify-ui
 cargo check -p desktop_runtime
 cargo check -p site
 cargo check -p desktop_tauri
 ```
 
-`cargo ui-dev` is the preferred browser/WASM preview workflow. `cargo ui-build` drives the corresponding build pipeline. Use the crate-level `cargo check` commands to validate focused changes in the shared runtime, browser entrypoint, and desktop host.
-`cargo ui-harden` performs the hardened release verification path: it cleans the workspace, runs two clean Trunk release builds into `build/wasm-hardening/`, compares the full deployable artifact graph, independently validates emitted SRI digests, and runs browser smoke validation when Node and Playwright browsers are available.
+`cargo ui-dev` is the preferred browser/WASM preview workflow. `cargo ui-build` drives the corresponding build pipeline. `cargo verify-ui` now exercises the preview toolchain with a real `site_app` wasm build, Trunk packaging, and a localhost smoke probe so wasm-only browser regressions are caught before merge. Use the crate-level `cargo check` commands for focused iteration in the shared runtime, browser entrypoint, and desktop host.
 
 ## Integration Patterns
 All UI-to-platform integration must flow through typed contracts.

--- a/ui/crates/platform_host_web/src/persistence.rs
+++ b/ui/crates/platform_host_web/src/persistence.rs
@@ -22,11 +22,14 @@ pub fn opfs_supported() -> bool {
         let Some(window) = web_sys::window() else {
             return false;
         };
-        js_sys::Reflect::get(
-            window.navigator().storage().as_ref(),
-            &"getDirectory".into(),
-        )
-        .is_ok()
+        let Ok(storage) = js_sys::Reflect::get(window.navigator().as_ref(), &"storage".into())
+        else {
+            return false;
+        };
+        if storage.is_undefined() || storage.is_null() {
+            return false;
+        }
+        js_sys::Reflect::get(&storage, &"getDirectory".into()).is_ok()
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/ui/crates/site/Cargo.toml
+++ b/ui/crates/site/Cargo.toml
@@ -25,5 +25,6 @@ leptos_router = { version = "0.6", default-features = false }
 platform_host_web = { path = "../platform_host_web", default-features = false }
 js-sys = "0.3"
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["BroadcastChannel", "Document", "Location", "MessageEvent", "Navigator", "ServiceWorkerContainer", "Url", "Window"] }
 console_error_panic_hook = "0.1"

--- a/ui/crates/site/src/pwa.rs
+++ b/ui/crates/site/src/pwa.rs
@@ -1,7 +1,13 @@
 //! Browser PWA/runtime enhancement helpers.
 
 #[cfg(target_arch = "wasm32")]
+use js_sys::Function;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsValue;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::JsFuture;
 
 #[cfg(target_arch = "wasm32")]
 const SERVICE_WORKER_ASSET: &str = "sw.js";
@@ -23,6 +29,55 @@ fn current_public_base_path() -> Option<String> {
     let base_uri = document.base_uri().ok().flatten()?;
     let url = web_sys::Url::new(&base_uri).ok()?;
     Some(url.pathname())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn current_hostname() -> Option<String> {
+    web_sys::window()?.location().hostname().ok()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_local_dev_host() -> bool {
+    matches!(
+        current_hostname().as_deref(),
+        Some("localhost") | Some("127.0.0.1") | Some("0.0.0.0")
+    )
+}
+
+#[cfg(target_arch = "wasm32")]
+fn unregister_service_workers(service_worker: JsValue) {
+    leptos::spawn_local(async move {
+        let Ok(get_registrations) = js_sys::Reflect::get(
+            &service_worker,
+            &wasm_bindgen::JsValue::from_str("getRegistrations"),
+        ) else {
+            return;
+        };
+        let Some(get_registrations_fn) = get_registrations.dyn_ref::<Function>() else {
+            return;
+        };
+        let Ok(registrations_promise) = get_registrations_fn.call0(&service_worker) else {
+            return;
+        };
+        let Ok(registrations_value) =
+            JsFuture::from(js_sys::Promise::from(registrations_promise)).await
+        else {
+            return;
+        };
+        let registrations = js_sys::Array::from(&registrations_value);
+        for registration in registrations.iter() {
+            let Ok(unregister) = js_sys::Reflect::get(
+                &registration,
+                &wasm_bindgen::JsValue::from_str("unregister"),
+            ) else {
+                continue;
+            };
+            let Some(unregister_fn) = unregister.dyn_ref::<Function>() else {
+                continue;
+            };
+            let _ = unregister_fn.call0(&registration);
+        }
+    });
 }
 
 /// Registers the service worker when the platform supports it.
@@ -49,6 +104,10 @@ pub fn register_service_worker() {
         ) else {
             return;
         };
+        if is_local_dev_host() {
+            unregister_service_workers(service_worker);
+            return;
+        }
         let Some(register_fn) = register.dyn_ref::<js_sys::Function>() else {
             return;
         };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,8 +3,12 @@ mod github;
 mod ui_hardening;
 
 use std::env;
+use std::io::{Read, Write};
+use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus};
+use std::process::{Child, Command, ExitStatus};
+use std::thread;
+use std::time::{Duration, Instant};
 
 const UI_PACKAGES: &[&str] = &[
     "desktop_app_contract",
@@ -38,6 +42,8 @@ const CORE_EXCLUDED_PACKAGES: &[&str] = &[
     "desktop_app_terminal",
     "wasmcloud-smoke-tests",
 ];
+
+const UI_PREVIEW_SMOKE_PORT: u16 = 8095;
 
 fn main() {
     if let Err(error) = run() {
@@ -189,6 +195,8 @@ fn run_verify(args: Vec<String>) -> Result<(), String> {
                 &workspace_root,
                 &package_command_with_packages(&["test", "--all-targets"], UI_PACKAGES, &[]),
             )?;
+            verify_ui_browser_manifest_hygiene(&workspace_root)?;
+            run_ui_preview_smoke(&workspace_root)?;
             run_ui(vec![
                 "build".to_string(),
                 "--features".to_string(),
@@ -353,6 +361,147 @@ fn cargo(workspace_root: &Path, args: &[&str]) -> Result<(), String> {
     run_command(&mut command)
 }
 
+fn run_ui_preview_smoke(workspace_root: &Path) -> Result<(), String> {
+    cargo(
+        workspace_root,
+        &[
+            "build",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--manifest-path",
+            "ui/crates/site/Cargo.toml",
+            "--bin",
+            "site_app",
+        ],
+    )?;
+
+    run_ui(vec![
+        "build".to_string(),
+        "--dist".to_string(),
+        "target/trunk-preview-dist".to_string(),
+    ])?;
+
+    let site_dir = workspace_root.join("ui/crates/site");
+    let mut command = Command::new("trunk");
+    command.current_dir(&site_dir);
+    command.arg("serve");
+    command.arg("index.html");
+    command.arg("--no-autoreload");
+    command.arg("--port");
+    command.arg(UI_PREVIEW_SMOKE_PORT.to_string());
+    sanitize_trunk_environment(&mut command);
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to start preview smoke server: {error}"))?;
+
+    let smoke_result =
+        wait_for_http_ready(&mut child, UI_PREVIEW_SMOKE_PORT, Duration::from_secs(30));
+    terminate_child(&mut child)?;
+    smoke_result
+}
+
+fn wait_for_http_ready(child: &mut Child, port: u16, timeout: Duration) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("failed to poll preview smoke server: {error}"))?
+        {
+            return Err(format!(
+                "preview smoke server exited before responding with status {status}"
+            ));
+        }
+
+        match probe_http_root(port) {
+            Ok(()) => return Ok(()),
+            Err(_) => thread::sleep(Duration::from_millis(250)),
+        }
+    }
+
+    Err(format!(
+        "preview smoke server did not respond on http://127.0.0.1:{port}/ within {}s",
+        timeout.as_secs()
+    ))
+}
+
+fn probe_http_root(port: u16) -> Result<(), String> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port))
+        .map_err(|error| format!("failed to connect to preview smoke server: {error}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("failed to configure preview smoke read timeout: {error}"))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("failed to configure preview smoke write timeout: {error}"))?;
+    stream
+        .write_all(b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+        .map_err(|error| format!("failed to send preview smoke request: {error}"))?;
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|error| format!("failed to read preview smoke response: {error}"))?;
+    if response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200") {
+        Ok(())
+    } else {
+        Err(format!(
+            "preview smoke server returned unexpected response: {}",
+            response.lines().next().unwrap_or("<empty>")
+        ))
+    }
+}
+
+fn terminate_child(child: &mut Child) -> Result<(), String> {
+    match child.try_wait() {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => {
+            child
+                .kill()
+                .map_err(|error| format!("failed to stop preview smoke server: {error}"))?;
+            child
+                .wait()
+                .map_err(|error| format!("failed to reap preview smoke server: {error}"))?;
+            Ok(())
+        }
+        Err(error) => Err(format!(
+            "failed to poll preview smoke server during shutdown: {error}"
+        )),
+    }
+}
+
+fn verify_ui_browser_manifest_hygiene(workspace_root: &Path) -> Result<(), String> {
+    let site_manifest = std::fs::read_to_string(workspace_root.join("ui/crates/site/Cargo.toml"))
+        .map_err(|error| format!("failed to read site manifest: {error}"))?;
+    if !site_manifest.contains("js-sys") {
+        return Err(
+            "site manifest must declare a direct `js-sys` dependency for reflective browser APIs"
+                .to_string(),
+        );
+    }
+
+    let persistence_source = std::fs::read_to_string(
+        workspace_root.join("ui/crates/platform_host_web/src/persistence.rs"),
+    )
+    .map_err(|error| format!("failed to read platform_host_web persistence source: {error}"))?;
+    if persistence_source.contains(".storage()") {
+        return Err(
+            "platform_host_web persistence probe must not depend on typed `Navigator.storage()` bindings"
+                .to_string(),
+        );
+    }
+    if !persistence_source
+        .contains("Reflect::get(window.navigator().as_ref(), &\"storage\".into())")
+    {
+        return Err(
+            "platform_host_web persistence probe must use reflective `navigator.storage` access"
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
 fn normalize_dist_arg(workspace_root: &Path, args: &mut [String]) {
     let mut index = 0usize;
     while index < args.len() {
@@ -376,8 +525,14 @@ fn drop_no_open_arg(args: &mut Vec<String>) {
 }
 
 fn sanitize_trunk_environment(command: &mut Command) {
-    if matches!(env::var("NO_COLOR").as_deref(), Ok("1")) {
-        command.env("NO_COLOR", "true");
+    if env::var_os("NO_COLOR").is_some() {
+        command.env_remove("NO_COLOR");
+    }
+    for key in env::vars_os().map(|(key, _)| key) {
+        let key = key.to_string_lossy();
+        if key.starts_with("CARGO_") && key != "CARGO_HOME" {
+            command.env_remove(key.as_ref());
+        }
     }
 }
 
@@ -437,10 +592,27 @@ fn help() -> String {
 mod tests {
     use super::{
         args_include_lattice, drop_no_open_arg, normalize_dist_arg, prepend_get_hosts,
-        sanitize_trunk_environment,
+        probe_http_root, sanitize_trunk_environment, verify_ui_browser_manifest_hygiene,
     };
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::path::Path;
     use std::process::Command;
+    use std::thread;
+
+    fn unique_temp_dir(label: &str) -> std::path::PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "xtask-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock drift")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&base).expect("create temp dir");
+        base
+    }
 
     #[test]
     fn normalize_dist_arg_absolutizes_split_flag_value() {
@@ -470,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_trunk_environment_normalizes_no_color_value() {
+    fn sanitize_trunk_environment_removes_no_color() {
         let original = std::env::var_os("NO_COLOR");
         std::env::set_var("NO_COLOR", "1");
 
@@ -481,7 +653,7 @@ mod tests {
             .get_envs()
             .find(|(key, _)| *key == "NO_COLOR")
             .and_then(|(_, value)| value);
-        assert_eq!(no_color, Some("true".as_ref()));
+        assert_eq!(no_color, None);
 
         if let Some(value) = original {
             std::env::set_var("NO_COLOR", value);
@@ -503,5 +675,59 @@ mod tests {
         assert!(args_include_lattice(&["--lattice=dev".to_string()]));
         assert!(args_include_lattice(&["-x".to_string()]));
         assert!(!args_include_lattice(&["--detached".to_string()]));
+    }
+
+    #[test]
+    fn probe_http_root_accepts_http_200() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
+        let port = listener.local_addr().expect("local addr").port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0u8; 128];
+            let _ = stream.read(&mut request);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .expect("write response");
+        });
+
+        probe_http_root(port).expect("probe should succeed");
+        server.join().expect("join server");
+    }
+
+    #[test]
+    fn verify_ui_browser_manifest_hygiene_accepts_expected_files() {
+        let root = unique_temp_dir("ui-browser-hygiene-pass");
+        let site_dir = root.join("ui/crates/site");
+        let host_dir = root.join("ui/crates/platform_host_web/src");
+        fs::create_dir_all(&site_dir).expect("create site dir");
+        fs::create_dir_all(&host_dir).expect("create host dir");
+        fs::write(site_dir.join("Cargo.toml"), "js-sys = \"0.3\"\n").expect("write site manifest");
+        fs::write(
+            host_dir.join("persistence.rs"),
+            "let _ = js_sys::Reflect::get(window.navigator().as_ref(), &\"storage\".into());\n",
+        )
+        .expect("write persistence source");
+
+        verify_ui_browser_manifest_hygiene(&root).expect("hygiene should pass");
+        fs::remove_dir_all(root).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn verify_ui_browser_manifest_hygiene_rejects_typed_storage_binding() {
+        let root = unique_temp_dir("ui-browser-hygiene-fail");
+        let site_dir = root.join("ui/crates/site");
+        let host_dir = root.join("ui/crates/platform_host_web/src");
+        fs::create_dir_all(&site_dir).expect("create site dir");
+        fs::create_dir_all(&host_dir).expect("create host dir");
+        fs::write(site_dir.join("Cargo.toml"), "js-sys = \"0.3\"\n").expect("write site manifest");
+        fs::write(
+            host_dir.join("persistence.rs"),
+            "window.navigator().storage();\n",
+        )
+        .expect("write persistence source");
+
+        let error = verify_ui_browser_manifest_hygiene(&root).expect_err("hygiene should fail");
+        assert!(error.contains("Navigator.storage"));
+        fs::remove_dir_all(root).expect("cleanup temp dir");
     }
 }


### PR DESCRIPTION
Partial follow-up for #53.

## Summary
- add preview smoke coverage and browser-manifest hygiene checks without regressing the hardened release pipeline
- keep the hardened Trunk/SRI verification path intact while adding local preview guardrails
- unregister service workers on localhost preview hosts to avoid stale dev caches

## Scope
- xtask preview smoke probe and browser-manifest hygiene assertions
- reflective OPFS capability detection in the browser host adapter
- localhost-only service-worker unregister path for preview sessions

## Verification
- cargo fmt --all --check
- cargo check -p xtask
- cargo check -p site --target wasm32-unknown-unknown --features csr
