### PR TITLE
Fix deterministic UI shell hydration and browser sync

### DIFF
--- a/ui/crates/desktop_runtime/src/host.rs
+++ b/ui/crates/desktop_runtime/src/host.rs
@@ -20,7 +20,10 @@ use platform_host::{
 };
 
 use crate::{
-    model::WindowRect, persistence, reducer::DesktopAction, runtime_context::DesktopRuntimeContext,
+    model::{DeepLinkState, WindowRect},
+    persistence,
+    reducer::DesktopAction,
+    runtime_context::DesktopRuntimeContext,
 };
 
 #[derive(Clone)]
@@ -107,12 +110,12 @@ impl DesktopHostContext {
 
     /// Installs boot hydration/migration side effects for the desktop provider.
     ///
-    /// This preserves the current boot sequence:
-    /// 1. hydrate from compatibility snapshot first (if present)
-    /// 2. asynchronously hydrate from durable storage if present
-    /// 3. otherwise migrate the legacy snapshot into durable storage
-    pub fn install_boot_hydration(&self, dispatch: Callback<DesktopAction>) {
-        boot::install_boot_hydration(self.clone(), dispatch);
+    pub fn install_boot_hydration(
+        &self,
+        dispatch: Callback<DesktopAction>,
+        initial_deep_link: Option<DeepLinkState>,
+    ) {
+        boot::install_boot_hydration(self.clone(), dispatch, initial_deep_link);
     }
 
     /// Executes a single [`crate::RuntimeEffect`] emitted by the reducer.

--- a/ui/crates/desktop_runtime/src/host/boot.rs
+++ b/ui/crates/desktop_runtime/src/host/boot.rs
@@ -1,65 +1,87 @@
 use leptos::{create_effect, logging, spawn_local, Callable, Callback};
 
 use crate::{
-    current_browser_e2e_config, host::DesktopHostContext, persistence, reducer::DesktopAction,
+    current_browser_e2e_config,
+    host::DesktopHostContext,
+    model::{DeepLinkState, DesktopSnapshot, DesktopTheme},
+    persistence::{self, AppPolicyOverlay, DurableDesktopSnapshot},
+    reducer::DesktopAction,
+    WallpaperConfig,
 };
 
-pub(super) fn install_boot_hydration(host: DesktopHostContext, dispatch: Callback<DesktopAction>) {
+#[derive(Debug, Clone, PartialEq)]
+enum AuthoritativeBootSnapshot {
+    Durable(DurableDesktopSnapshot),
+    Legacy(DesktopSnapshot),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct BootHydrationPlan {
+    snapshot: Option<AuthoritativeBootSnapshot>,
+    migrate_legacy_snapshot: Option<DesktopSnapshot>,
+    theme: Option<DesktopTheme>,
+    wallpaper: Option<WallpaperConfig>,
+    policy_overlay: Option<AppPolicyOverlay>,
+    deep_link: Option<DeepLinkState>,
+}
+
+impl BootHydrationPlan {
+    fn empty(initial_deep_link: Option<DeepLinkState>) -> Self {
+        Self {
+            snapshot: None,
+            migrate_legacy_snapshot: None,
+            theme: None,
+            wallpaper: None,
+            policy_overlay: None,
+            deep_link: initial_deep_link.filter(|deep_link| !deep_link.open.is_empty()),
+        }
+    }
+}
+
+pub(super) fn install_boot_hydration(
+    host: DesktopHostContext,
+    dispatch: Callback<DesktopAction>,
+    initial_deep_link: Option<DeepLinkState>,
+) {
     create_effect(move |_| {
         let dispatch = dispatch;
         let boot_host = host.clone();
+        let boot_deep_link = initial_deep_link.clone();
         spawn_local(async move {
             let browser_e2e_active = current_browser_e2e_config().is_some();
-
-            if !browser_e2e_active {
+            let plan = if browser_e2e_active {
+                BootHydrationPlan::empty(None)
+            } else {
                 let legacy_snapshot = persistence::load_boot_snapshot(&boot_host).await;
-                let durable_snapshot = persistence::load_durable_boot_snapshot(&boot_host).await;
-                let restore_preferences = persistence::resolve_restore_preferences(
-                    durable_snapshot.as_ref(),
-                    legacy_snapshot.as_ref(),
-                );
+                let durable_snapshot =
+                    persistence::load_durable_boot_snapshot_record(&boot_host).await;
+                let theme = persistence::load_theme(&boot_host).await;
+                let wallpaper = persistence::load_wallpaper(&boot_host).await;
+                let policy_overlay = persistence::load_app_policy_overlay(&boot_host).await;
+                resolve_boot_hydration_plan(
+                    durable_snapshot,
+                    legacy_snapshot,
+                    theme,
+                    wallpaper,
+                    policy_overlay,
+                    boot_deep_link,
+                )
+            };
 
-                if let Some(policy) = persistence::load_app_policy_overlay(&boot_host).await {
-                    dispatch.call(DesktopAction::HydratePolicyOverlay {
-                        privileged_app_ids: policy.privileged_app_ids,
-                    });
-                }
-                if restore_preferences.restore_on_boot {
-                    if let Some(snapshot) = legacy_snapshot.clone() {
-                        dispatch.call(DesktopAction::HydrateSnapshot {
-                            snapshot,
-                            mode: crate::reducer::HydrationMode::BootRestore,
-                        });
-                    }
-                }
+            let (snapshot, snapshot_revision) =
+                resolve_authoritative_snapshot(&boot_host, &plan).await;
 
-                if let Some(theme) = persistence::load_theme(&boot_host).await {
-                    dispatch.call(DesktopAction::HydrateTheme { theme });
-                }
-
-                if let Some(wallpaper) = persistence::load_wallpaper(&boot_host).await {
-                    dispatch.call(DesktopAction::HydrateWallpaper { wallpaper });
-                }
-
-                if restore_preferences.restore_on_boot {
-                    if let Some(snapshot) = durable_snapshot.clone() {
-                        dispatch.call(DesktopAction::HydrateSnapshot {
-                            snapshot,
-                            mode: crate::reducer::HydrationMode::BootRestore,
-                        });
-                    }
-                } else if let Some(snapshot) = legacy_snapshot.clone() {
-                    let migrated_state = crate::model::DesktopState::from_snapshot(snapshot);
-                    if let Err(err) =
-                        persistence::persist_durable_layout_snapshot(&boot_host, &migrated_state)
-                            .await
-                    {
-                        logging::warn!("migrate legacy snapshot to durable store failed: {err}");
-                    }
-                }
-            }
-
-            dispatch.call(DesktopAction::BootHydrationComplete);
+            dispatch.call(DesktopAction::CompleteBootHydration {
+                snapshot,
+                snapshot_revision,
+                theme: plan.theme,
+                wallpaper: plan.wallpaper,
+                privileged_app_ids: plan
+                    .policy_overlay
+                    .map(|policy| policy.privileged_app_ids)
+                    .unwrap_or_default(),
+                deep_link: plan.deep_link,
+            });
         });
 
         let host = host.clone();
@@ -72,4 +94,144 @@ pub(super) fn install_boot_hydration(host: DesktopHostContext, dispatch: Callbac
             }
         });
     });
+}
+
+fn resolve_boot_hydration_plan(
+    durable_snapshot: Option<DurableDesktopSnapshot>,
+    legacy_snapshot: Option<DesktopSnapshot>,
+    theme: Option<DesktopTheme>,
+    wallpaper: Option<WallpaperConfig>,
+    policy_overlay: Option<AppPolicyOverlay>,
+    deep_link: Option<DeepLinkState>,
+) -> BootHydrationPlan {
+    let durable_present = durable_snapshot.is_some();
+    let restore_preferences = persistence::resolve_restore_preferences(
+        durable_snapshot.as_ref().map(|snapshot| &snapshot.snapshot),
+        legacy_snapshot.as_ref(),
+    );
+    let restore_snapshot = if restore_preferences.restore_on_boot {
+        durable_snapshot
+            .map(AuthoritativeBootSnapshot::Durable)
+            .or_else(|| {
+                legacy_snapshot
+                    .clone()
+                    .map(AuthoritativeBootSnapshot::Legacy)
+            })
+    } else {
+        None
+    };
+    let migrate_legacy_snapshot = (!durable_present).then_some(legacy_snapshot).flatten();
+
+    BootHydrationPlan {
+        snapshot: restore_snapshot,
+        migrate_legacy_snapshot,
+        theme,
+        wallpaper,
+        policy_overlay,
+        deep_link: deep_link.filter(|parsed| !parsed.open.is_empty()),
+    }
+}
+
+async fn resolve_authoritative_snapshot(
+    host: &DesktopHostContext,
+    plan: &BootHydrationPlan,
+) -> (Option<DesktopSnapshot>, Option<u64>) {
+    let Some(migration_snapshot) = plan.migrate_legacy_snapshot.clone() else {
+        return match &plan.snapshot {
+            Some(AuthoritativeBootSnapshot::Durable(snapshot)) => {
+                (Some(snapshot.snapshot.clone()), Some(snapshot.revision))
+            }
+            Some(AuthoritativeBootSnapshot::Legacy(snapshot)) => (Some(snapshot.clone()), None),
+            None => (None, None),
+        };
+    };
+
+    let migrated_state = crate::model::DesktopState::from_snapshot(migration_snapshot.clone());
+    match persistence::build_durable_layout_envelope(&migrated_state) {
+        Ok(envelope) => {
+            let revision = envelope.updated_at_unix_ms;
+            if let Err(err) = persistence::save_durable_layout_envelope(host, &envelope).await {
+                logging::warn!("migrate legacy snapshot to durable store failed: {err}");
+            }
+
+            match &plan.snapshot {
+                Some(AuthoritativeBootSnapshot::Durable(snapshot)) => {
+                    (Some(snapshot.snapshot.clone()), Some(snapshot.revision))
+                }
+                Some(AuthoritativeBootSnapshot::Legacy(_)) => {
+                    (Some(migration_snapshot), Some(revision))
+                }
+                None => (None, Some(revision)),
+            }
+        }
+        Err(err) => {
+            logging::warn!("build durable snapshot envelope for legacy migration failed: {err}");
+            match &plan.snapshot {
+                Some(AuthoritativeBootSnapshot::Durable(snapshot)) => {
+                    (Some(snapshot.snapshot.clone()), Some(snapshot.revision))
+                }
+                Some(AuthoritativeBootSnapshot::Legacy(snapshot)) => (Some(snapshot.clone()), None),
+                None => (None, None),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::DesktopPreferences;
+
+    fn snapshot_with_restore(restore_on_boot: bool) -> DesktopSnapshot {
+        let mut snapshot = crate::model::DesktopState::default().snapshot();
+        snapshot.preferences = DesktopPreferences {
+            restore_on_boot,
+            ..DesktopPreferences::default()
+        };
+        snapshot
+    }
+
+    #[test]
+    fn durable_snapshot_is_authoritative_for_boot_restore() {
+        let durable = DurableDesktopSnapshot {
+            snapshot: snapshot_with_restore(true),
+            revision: 44,
+        };
+        let legacy = snapshot_with_restore(true);
+        let plan = resolve_boot_hydration_plan(
+            Some(durable.clone()),
+            Some(legacy),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(
+            plan.snapshot,
+            Some(AuthoritativeBootSnapshot::Durable(durable))
+        );
+        assert!(plan.migrate_legacy_snapshot.is_none());
+    }
+
+    #[test]
+    fn legacy_snapshot_is_migrated_even_when_restore_is_disabled() {
+        let legacy = snapshot_with_restore(false);
+        let plan = resolve_boot_hydration_plan(None, Some(legacy.clone()), None, None, None, None);
+
+        assert!(plan.snapshot.is_none());
+        assert_eq!(plan.migrate_legacy_snapshot, Some(legacy));
+    }
+
+    #[test]
+    fn legacy_snapshot_restores_once_and_migrates_once() {
+        let legacy = snapshot_with_restore(true);
+        let plan = resolve_boot_hydration_plan(None, Some(legacy.clone()), None, None, None, None);
+
+        assert_eq!(
+            plan.snapshot,
+            Some(AuthoritativeBootSnapshot::Legacy(legacy.clone()))
+        );
+        assert_eq!(plan.migrate_legacy_snapshot, Some(legacy));
+    }
 }

--- a/ui/crates/desktop_runtime/src/host/effects.rs
+++ b/ui/crates/desktop_runtime/src/host/effects.rs
@@ -12,9 +12,6 @@ pub(super) fn run_runtime_effect(
     effect: RuntimeEffect,
 ) {
     match effect {
-        RuntimeEffect::ParseAndOpenDeepLink(deep_link) => {
-            host_ui::open_deep_link(runtime, deep_link)
-        }
         RuntimeEffect::PersistLayout => persistence_effects::persist_layout(host, runtime),
         RuntimeEffect::PersistTheme => persistence_effects::persist_theme(host, runtime),
         RuntimeEffect::PersistWallpaper => persistence_effects::persist_wallpaper(host, runtime),

--- a/ui/crates/desktop_runtime/src/host/host_ui.rs
+++ b/ui/crates/desktop_runtime/src/host/host_ui.rs
@@ -4,39 +4,7 @@ use leptos::{logging, spawn_local};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{closure::Closure, JsCast};
 
-use crate::{
-    components::DesktopRuntimeContext,
-    host::DesktopHostContext,
-    model::WindowRect,
-    reducer::{build_open_request_from_deeplink, DesktopAction},
-};
-use system_ui::tokens::SHELL_TASKBAR_HEIGHT_PX;
-
-pub(super) fn open_deep_link(
-    runtime: DesktopRuntimeContext,
-    deep_link: crate::model::DeepLinkState,
-) {
-    for target in deep_link.open {
-        match target {
-            crate::model::DeepLinkOpenTarget::App(app_id) => {
-                runtime.dispatch_action(DesktopAction::ActivateApp {
-                    app_id,
-                    viewport: Some(
-                        runtime
-                            .host
-                            .get_value()
-                            .desktop_viewport_rect(SHELL_TASKBAR_HEIGHT_PX),
-                    ),
-                });
-            }
-            target => {
-                runtime.dispatch_action(DesktopAction::OpenWindow(
-                    build_open_request_from_deeplink(target),
-                ));
-            }
-        }
-    }
-}
+use crate::{host::DesktopHostContext, model::WindowRect};
 
 pub(super) fn focus_window_input(window_id: crate::model::WindowId) {
     #[cfg(target_arch = "wasm32")]

--- a/ui/crates/desktop_runtime/src/host/persistence_effects.rs
+++ b/ui/crates/desktop_runtime/src/host/persistence_effects.rs
@@ -1,38 +1,78 @@
 use leptos::{logging, spawn_local, SignalGetUntracked};
-use platform_host::save_pref_with;
-use platform_host_web::{publish_shell_sync_event, ShellSyncEvent};
+use platform_host::{next_monotonic_timestamp_ms, save_pref_with};
+use platform_host_web::{publish_shell_sync_event, ShellSyncEvent, ShellSyncKind};
 
-use crate::{components::DesktopRuntimeContext, host::DesktopHostContext, persistence};
+use crate::{
+    components::DesktopRuntimeContext,
+    host::DesktopHostContext,
+    persistence,
+    reducer::{DesktopAction, SyncDomain},
+};
 
 pub(super) fn persist_layout(host: DesktopHostContext, runtime: DesktopRuntimeContext) {
     let snapshot_state = runtime.state.get_untracked();
     if let Err(err) = persistence::persist_layout_snapshot(&snapshot_state) {
         logging::warn!("persist layout failed: {err}");
     }
-    host.persist_durable_snapshot(snapshot_state, "layout");
-    publish_shell_sync_event(ShellSyncEvent::LayoutChanged);
+    match persistence::build_durable_layout_envelope(&snapshot_state) {
+        Ok(envelope) => {
+            let revision = envelope.updated_at_unix_ms;
+            runtime.dispatch_action(DesktopAction::RecordAppliedRevision {
+                domain: SyncDomain::Layout,
+                revision,
+            });
+            let async_host = host.clone();
+            spawn_local(async move {
+                if let Err(err) =
+                    persistence::save_durable_layout_envelope(&async_host, &envelope).await
+                {
+                    logging::warn!("persist durable layout failed: {err}");
+                    return;
+                }
+                publish_shell_sync_event(&ShellSyncEvent::new(ShellSyncKind::Layout, revision));
+            });
+        }
+        Err(err) => logging::warn!("build durable layout envelope failed: {err}"),
+    }
 }
 
 pub(super) fn persist_theme(host: DesktopHostContext, runtime: DesktopRuntimeContext) {
     let theme = runtime.state.get_untracked().theme;
+    let snapshot_state = runtime.state.get_untracked();
+    let revision = next_monotonic_timestamp_ms();
+    runtime.dispatch_action(DesktopAction::RecordAppliedRevision {
+        domain: SyncDomain::Theme,
+        revision,
+    });
     let async_host = host.clone();
     spawn_local(async move {
         if let Err(err) = persistence::persist_theme(&async_host, &theme).await {
             logging::warn!("persist theme failed: {err}");
         }
+        if let Ok(envelope) = persistence::build_durable_layout_envelope(&snapshot_state) {
+            if let Err(err) =
+                persistence::save_durable_layout_envelope(&async_host, &envelope).await
+            {
+                logging::warn!("persist theme durable snapshot failed: {err}");
+            }
+        }
+        publish_shell_sync_event(&ShellSyncEvent::new(ShellSyncKind::Theme, revision));
     });
-    host.persist_durable_snapshot(runtime.state.get_untracked(), "theme");
-    publish_shell_sync_event(ShellSyncEvent::ThemeChanged);
 }
 
 pub(super) fn persist_wallpaper(host: DesktopHostContext, runtime: DesktopRuntimeContext) {
     let wallpaper = runtime.state.get_untracked().wallpaper;
+    let revision = next_monotonic_timestamp_ms();
+    runtime.dispatch_action(DesktopAction::RecordAppliedRevision {
+        domain: SyncDomain::Wallpaper,
+        revision,
+    });
     spawn_local(async move {
         if let Err(err) = persistence::persist_wallpaper(&host, &wallpaper).await {
             logging::warn!("persist wallpaper failed: {err}");
         }
+        publish_shell_sync_event(&ShellSyncEvent::new(ShellSyncKind::Wallpaper, revision));
     });
-    publish_shell_sync_event(ShellSyncEvent::WallpaperChanged);
 }
 
 pub(super) fn persist_terminal_history(host: DesktopHostContext, runtime: DesktopRuntimeContext) {

--- a/ui/crates/desktop_runtime/src/lib.rs
+++ b/ui/crates/desktop_runtime/src/lib.rs
@@ -32,7 +32,7 @@
 //!     &mut state,
 //!     &mut interaction,
 //!     DesktopAction::OpenWindow(OpenWindowRequest::new(
-//!         ApplicationId::trusted("system.calculator"),
+//!         ApplicationId::trusted("system.settings"),
 //!     )),
 //! )
 //! .expect("reducer should open a window");
@@ -80,8 +80,9 @@ pub use host::DesktopHostContext;
 pub use model::*;
 /// Re-exported persistence entrypoints used by the shell runtime.
 pub use persistence::{
-    load_boot_snapshot, load_durable_boot_snapshot, load_theme, load_wallpaper,
-    persist_layout_snapshot, persist_terminal_history, persist_theme, persist_wallpaper,
+    load_boot_snapshot, load_durable_boot_snapshot, load_durable_boot_snapshot_record, load_theme,
+    load_wallpaper, persist_layout_snapshot, persist_terminal_history, persist_theme,
+    persist_wallpaper, DurableDesktopSnapshot,
 };
 /// Re-exported wallpaper contracts owned by the host boundary.
 pub use platform_host::{
@@ -90,6 +91,6 @@ pub use platform_host::{
     WallpaperMediaKind, WallpaperPosition, WallpaperSelection, WallpaperSourceKind,
 };
 /// Re-exported reducer entrypoint and core action/effect enums.
-pub use reducer::{reduce_desktop, DesktopAction, HydrationMode, RuntimeEffect};
+pub use reducer::{reduce_desktop, DesktopAction, HydrationMode, RuntimeEffect, SyncDomain};
 /// Re-exported shared UI primitives for runtime-owned shell surfaces.
 pub use system_ui::prelude::{Icon, IconName, IconSize};

--- a/ui/crates/desktop_runtime/src/model.rs
+++ b/ui/crates/desktop_runtime/src/model.rs
@@ -215,6 +215,15 @@ pub struct DesktopState {
     /// App ids elevated by the runtime policy overlay for this session.
     #[serde(skip)]
     pub privileged_app_ids: BTreeSet<String>,
+    /// Last applied durable/sync revision for layout state.
+    #[serde(skip)]
+    pub layout_revision: Option<u64>,
+    /// Last applied durable/sync revision for theme state.
+    #[serde(skip)]
+    pub theme_revision: Option<u64>,
+    /// Last applied durable/sync revision for wallpaper state.
+    #[serde(skip)]
+    pub wallpaper_revision: Option<u64>,
 }
 
 impl Default for DesktopState {
@@ -235,6 +244,9 @@ impl Default for DesktopState {
             app_shared_state: BTreeMap::new(),
             boot_hydrated: false,
             privileged_app_ids: BTreeSet::new(),
+            layout_revision: None,
+            theme_revision: None,
+            wallpaper_revision: None,
         }
     }
 }
@@ -262,7 +274,7 @@ impl DesktopState {
     pub fn from_snapshot(snapshot: DesktopSnapshot) -> Self {
         let mut state = Self::default();
         state.preferences = snapshot.preferences;
-        state.windows = snapshot.windows;
+        state.windows = normalize_restored_windows(snapshot.windows);
         state.terminal_history = snapshot.terminal_history;
         state.app_shared_state = snapshot.app_shared_state;
         state.boot_hydrated = false;
@@ -273,8 +285,59 @@ impl DesktopState {
             .max()
             .unwrap_or(0)
             .saturating_add(1);
+        state.active_modal = restored_active_modal(&state.windows);
         state
     }
+}
+
+fn normalize_restored_windows(mut windows: Vec<WindowRecord>) -> Vec<WindowRecord> {
+    let ids = windows
+        .iter()
+        .map(|window| window.id)
+        .collect::<BTreeSet<_>>();
+    windows.retain(|window| {
+        window
+            .flags
+            .modal_parent
+            .is_none_or(|parent_id| ids.contains(&parent_id))
+    });
+
+    let active_modal = windows
+        .iter()
+        .filter(|window| window.flags.modal_parent.is_some())
+        .max_by_key(|window| (window.z_index, window.id))
+        .map(|window| window.id);
+    windows.retain(|window| window.flags.modal_parent.is_none() || Some(window.id) == active_modal);
+
+    let focused = if let Some(modal_id) = active_modal {
+        Some(modal_id)
+    } else {
+        windows
+            .iter()
+            .filter(|window| window.is_focused)
+            .max_by_key(|window| (window.z_index, window.id))
+            .map(|window| window.id)
+            .or_else(|| {
+                windows
+                    .iter()
+                    .filter(|window| !window.minimized)
+                    .max_by_key(|window| (window.z_index, window.id))
+                    .map(|window| window.id)
+            })
+    };
+
+    for window in &mut windows {
+        window.is_focused = Some(window.id) == focused;
+    }
+
+    windows
+}
+
+fn restored_active_modal(windows: &[WindowRecord]) -> Option<WindowId> {
+    windows
+        .iter()
+        .find(|window| window.flags.modal_parent.is_some())
+        .map(|window| window.id)
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -591,5 +654,114 @@ mod tests {
             windows[0].get("last_lifecycle_event").is_none(),
             "snapshot should not persist runtime lifecycle markers"
         );
+    }
+
+    #[test]
+    fn from_snapshot_drops_orphaned_modal_children() {
+        let state = DesktopState::from_snapshot(DesktopSnapshot {
+            schema_version: DESKTOP_LAYOUT_SCHEMA_VERSION,
+            preferences: DesktopPreferences::default(),
+            windows: vec![
+                WindowRecord {
+                    id: WindowId(1),
+                    app_id: ApplicationId::trusted("system.settings"),
+                    title: "Parent".to_string(),
+                    icon_id: "settings".to_string(),
+                    rect: WindowRect::default(),
+                    restore_rect: None,
+                    z_index: 1,
+                    is_focused: true,
+                    minimized: false,
+                    maximized: false,
+                    suspended: false,
+                    flags: WindowFlags::default(),
+                    persist_key: None,
+                    app_state: Value::Null,
+                    launch_params: Value::Null,
+                    last_lifecycle_event: None,
+                },
+                WindowRecord {
+                    id: WindowId(2),
+                    app_id: ApplicationId::trusted("system.settings"),
+                    title: "Orphan".to_string(),
+                    icon_id: "settings".to_string(),
+                    rect: WindowRect::default(),
+                    restore_rect: None,
+                    z_index: 2,
+                    is_focused: false,
+                    minimized: false,
+                    maximized: false,
+                    suspended: false,
+                    flags: WindowFlags {
+                        modal_parent: Some(WindowId(99)),
+                        ..WindowFlags::default()
+                    },
+                    persist_key: None,
+                    app_state: Value::Null,
+                    launch_params: Value::Null,
+                    last_lifecycle_event: None,
+                },
+            ],
+            terminal_history: Vec::new(),
+            app_shared_state: BTreeMap::new(),
+        });
+
+        assert_eq!(state.windows.len(), 1);
+        assert_eq!(state.active_modal, None);
+        assert_eq!(state.focused_window_id(), Some(WindowId(1)));
+    }
+
+    #[test]
+    fn from_snapshot_promotes_single_valid_modal_child_to_active_modal() {
+        let state = DesktopState::from_snapshot(DesktopSnapshot {
+            schema_version: DESKTOP_LAYOUT_SCHEMA_VERSION,
+            preferences: DesktopPreferences::default(),
+            windows: vec![
+                WindowRecord {
+                    id: WindowId(1),
+                    app_id: ApplicationId::trusted("system.settings"),
+                    title: "Parent".to_string(),
+                    icon_id: "settings".to_string(),
+                    rect: WindowRect::default(),
+                    restore_rect: None,
+                    z_index: 1,
+                    is_focused: true,
+                    minimized: false,
+                    maximized: false,
+                    suspended: false,
+                    flags: WindowFlags::default(),
+                    persist_key: None,
+                    app_state: Value::Null,
+                    launch_params: Value::Null,
+                    last_lifecycle_event: None,
+                },
+                WindowRecord {
+                    id: WindowId(2),
+                    app_id: ApplicationId::trusted("system.settings"),
+                    title: "Modal".to_string(),
+                    icon_id: "settings".to_string(),
+                    rect: WindowRect::default(),
+                    restore_rect: None,
+                    z_index: 2,
+                    is_focused: false,
+                    minimized: false,
+                    maximized: false,
+                    suspended: false,
+                    flags: WindowFlags {
+                        modal_parent: Some(WindowId(1)),
+                        ..WindowFlags::default()
+                    },
+                    persist_key: None,
+                    app_state: Value::Null,
+                    launch_params: Value::Null,
+                    last_lifecycle_event: None,
+                },
+            ],
+            terminal_history: Vec::new(),
+            app_shared_state: BTreeMap::new(),
+        });
+
+        assert_eq!(state.active_modal, Some(WindowId(2)));
+        assert_eq!(state.focused_window_id(), Some(WindowId(2)));
     }
 }

--- a/ui/crates/desktop_runtime/src/persistence.rs
+++ b/ui/crates/desktop_runtime/src/persistence.rs
@@ -2,11 +2,10 @@
 
 use crate::host::DesktopHostContext;
 use crate::model::{DesktopPreferences, DesktopSnapshot, DesktopState, DesktopTheme};
-#[cfg(test)]
 use platform_host::build_app_state_envelope;
 use platform_host::{
-    load_app_state_with_migration, load_pref_with, migrate_envelope_payload, save_app_state_with,
-    save_pref_with, AppStateEnvelope, WallpaperConfig, WallpaperSelection, DESKTOP_STATE_NAMESPACE,
+    load_pref_with, migrate_envelope_payload, save_pref_with, AppStateEnvelope, WallpaperConfig,
+    WallpaperSelection, DESKTOP_STATE_NAMESPACE,
 };
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +23,15 @@ pub const APP_POLICY_KEY: &str = "system.app_policy.v1";
 pub struct AppPolicyOverlay {
     /// App ids treated as privileged by shell policy.
     pub privileged_app_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Typed durable desktop snapshot with the applied app-state revision.
+pub struct DurableDesktopSnapshot {
+    /// Decoded desktop snapshot payload.
+    pub snapshot: DesktopSnapshot,
+    /// Monotonic durable app-state revision.
+    pub revision: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -114,18 +122,32 @@ pub async fn load_boot_snapshot(_host: &DesktopHostContext) -> Option<DesktopSna
 /// Loads the durable boot snapshot from the configured [`platform_host::AppStateStore`]
 /// implementation (IndexedDB-backed in the browser host).
 pub async fn load_durable_boot_snapshot(host: &DesktopHostContext) -> Option<DesktopSnapshot> {
+    load_durable_boot_snapshot_record(host)
+        .await
+        .map(|record| record.snapshot)
+}
+
+/// Loads the durable boot snapshot together with its authoritative app-state revision.
+pub async fn load_durable_boot_snapshot_record(
+    host: &DesktopHostContext,
+) -> Option<DurableDesktopSnapshot> {
     let store = host.app_state_store();
-    match load_app_state_with_migration(
-        store.as_ref(),
-        DESKTOP_STATE_NAMESPACE,
-        crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION,
-        migrate_desktop_snapshot,
-    )
-    .await
-    {
-        Ok(snapshot) => snapshot,
+    let envelope = match store.load_app_state_envelope(DESKTOP_STATE_NAMESPACE).await {
+        Ok(envelope) => envelope,
         Err(err) => {
             leptos::logging::warn!("durable boot snapshot load failed: {err}");
+            return None;
+        }
+    }?;
+
+    match decode_desktop_snapshot_envelope(&envelope) {
+        Ok(Some(snapshot)) => Some(DurableDesktopSnapshot {
+            snapshot,
+            revision: envelope.updated_at_unix_ms,
+        }),
+        Ok(None) => None,
+        Err(err) => {
+            leptos::logging::warn!("durable boot snapshot decode failed: {err}");
             None
         }
     }
@@ -148,15 +170,27 @@ pub async fn persist_durable_layout_snapshot(
     host: &DesktopHostContext,
     state: &DesktopState,
 ) -> Result<(), String> {
-    let snapshot = state.snapshot();
-    let store = host.app_state_store();
-    save_app_state_with(
-        store.as_ref(),
+    let envelope = build_durable_layout_envelope(state)?;
+    save_durable_layout_envelope(host, &envelope).await
+}
+
+/// Builds a durable desktop layout envelope and stamps it with a monotonic revision.
+pub fn build_durable_layout_envelope(state: &DesktopState) -> Result<AppStateEnvelope, String> {
+    build_app_state_envelope(
         DESKTOP_STATE_NAMESPACE,
         crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION,
-        &snapshot,
+        &state.snapshot(),
     )
-    .await
+}
+
+/// Persists a durable desktop layout envelope through the configured app-state store.
+pub async fn save_durable_layout_envelope(
+    host: &DesktopHostContext,
+    envelope: &AppStateEnvelope,
+) -> Result<(), String> {
+    host.app_state_store()
+        .save_app_state_envelope(envelope)
+        .await
 }
 
 /// Persists compatibility layout state.
@@ -282,9 +316,23 @@ fn local_storage() -> Option<web_sys::Storage> {
     web_sys::window()?.local_storage().ok().flatten()
 }
 
+fn decode_desktop_snapshot_envelope(
+    envelope: &AppStateEnvelope,
+) -> Result<Option<DesktopSnapshot>, String> {
+    if envelope.schema_version == crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION {
+        migrate_envelope_payload(envelope).map(Some)
+    } else if envelope.schema_version > crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION {
+        Ok(None)
+    } else {
+        migrate_desktop_snapshot(envelope.schema_version, envelope)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::executor::block_on;
+    use platform_host::{AppStateStore, MemoryAppStateStore};
 
     #[test]
     fn desktop_namespace_migration_supports_schema_zero() {
@@ -312,5 +360,31 @@ mod tests {
 
         let legacy_only = resolve_restore_preferences(None, Some(&legacy));
         assert!(!legacy_only.restore_on_boot);
+    }
+
+    #[test]
+    fn durable_snapshot_record_preserves_revision() {
+        let store = MemoryAppStateStore::default();
+        let state = DesktopState::default();
+        let envelope =
+            build_durable_layout_envelope(&state).expect("durable desktop envelope should build");
+        let revision = envelope.updated_at_unix_ms;
+        block_on(store.save_app_state_envelope(&envelope)).expect("save envelope");
+        let host = crate::host::DesktopHostContext::new(platform_host::HostServices {
+            app_state: std::rc::Rc::new(store),
+            prefs: std::rc::Rc::new(platform_host::NoopPrefsStore),
+            explorer: std::rc::Rc::new(platform_host::NoopExplorerFsService),
+            cache: std::rc::Rc::new(platform_host::NoopContentCache),
+            external_urls: std::rc::Rc::new(platform_host::NoopExternalUrlService),
+            notifications: std::rc::Rc::new(platform_host::NoopNotificationService),
+            wallpaper: std::rc::Rc::new(platform_host::NoopWallpaperAssetService),
+            terminal_process: None,
+            capabilities: platform_host::HostCapabilities::browser(),
+            host_strategy: platform_host::HostStrategy::Browser,
+        });
+
+        let loaded = block_on(load_durable_boot_snapshot_record(&host)).expect("durable snapshot");
+        assert_eq!(loaded.revision, revision);
+        assert_eq!(loaded.snapshot, state.snapshot());
     }
 }

--- a/ui/crates/desktop_runtime/src/reducer.rs
+++ b/ui/crates/desktop_runtime/src/reducer.rs
@@ -144,11 +144,15 @@ pub enum DesktopAction {
     HydrateTheme {
         /// Persisted theme payload.
         theme: DesktopTheme,
+        /// Revision associated with the theme payload.
+        revision: Option<u64>,
     },
     /// Hydrate wallpaper state independently from layout restore.
     HydrateWallpaper {
         /// Persisted wallpaper payload.
         wallpaper: WallpaperConfig,
+        /// Revision associated with the wallpaper payload.
+        revision: Option<u64>,
     },
     /// Replace the wallpaper library snapshot.
     WallpaperLibraryLoaded {
@@ -208,25 +212,42 @@ pub enum DesktopAction {
         /// Shared state payload.
         state: Value,
     },
+    /// Complete boot hydration in a single deterministic transition.
+    CompleteBootHydration {
+        /// Authoritative snapshot to restore when boot restore is enabled.
+        snapshot: Option<DesktopSnapshot>,
+        /// Durable revision for the authoritative snapshot when one exists.
+        snapshot_revision: Option<u64>,
+        /// Persisted theme payload.
+        theme: Option<DesktopTheme>,
+        /// Persisted wallpaper payload.
+        wallpaper: Option<WallpaperConfig>,
+        /// Persisted policy overlay payload.
+        privileged_app_ids: Vec<String>,
+        /// Initial deep-link payload captured at mount.
+        deep_link: Option<DeepLinkState>,
+    },
     /// Hydrate runtime state from a persisted snapshot.
     HydrateSnapshot {
         /// Snapshot payload to restore.
         snapshot: DesktopSnapshot,
         /// Hydration intent controlling lifecycle replay.
         mode: HydrationMode,
-    },
-    /// Hydrates the runtime policy overlay for the current session.
-    HydratePolicyOverlay {
-        /// App ids elevated by the policy overlay.
-        privileged_app_ids: Vec<String>,
+        /// Revision associated with the snapshot payload.
+        revision: Option<u64>,
     },
     /// Apply URL-derived deep-link instructions.
     ApplyDeepLink {
         /// Parsed deep-link payload.
         deep_link: DeepLinkState,
     },
-    /// Marks asynchronous boot hydration as complete for the current runtime session.
-    BootHydrationComplete,
+    /// Records the latest applied sync revision for a state domain.
+    RecordAppliedRevision {
+        /// State domain whose monotonic revision advanced.
+        domain: SyncDomain,
+        /// New monotonic revision value.
+        revision: u64,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -242,8 +263,6 @@ pub enum RuntimeEffect {
     PersistTerminalHistory,
     /// Move focus into the newly focused window's primary input.
     FocusWindowInput(WindowId),
-    /// Parse and open deep-link targets in the UI layer.
-    ParseAndOpenDeepLink(DeepLinkState),
     /// Open an external URL (for app actions that leave the shell).
     OpenExternalUrl(String),
     /// Play a named UI sound effect.
@@ -350,6 +369,17 @@ pub enum HydrationMode {
     BootRestore,
     /// Synchronizes persisted state into an already-running session.
     SyncRefresh,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// State domains that participate in monotonic cross-context synchronization.
+pub enum SyncDomain {
+    /// Desktop layout snapshot state.
+    Layout,
+    /// Theme and accessibility preference state.
+    Theme,
+    /// Wallpaper preference state.
+    Wallpaper,
 }
 
 #[derive(Debug, Error, Clone, PartialEq)]
@@ -516,6 +546,7 @@ pub fn reduce_desktop(
             ensure_parent_close_allowed(state, window_id)?;
             let was_focused = state.focused_window_id() == Some(window_id);
             let modal_parent_to_focus = complete_modal_close(state, window_id);
+            clear_interaction_for_window(interaction, window_id);
             effects.push(RuntimeEffect::DispatchLifecycle {
                 window_id,
                 event: AppLifecycleEvent::Closing,
@@ -1044,49 +1075,62 @@ pub fn reduce_desktop(
             state.app_shared_state.insert(storage_key, shared);
             effects.push(RuntimeEffect::PersistLayout);
         }
-        DesktopAction::HydrateSnapshot { snapshot, mode } => {
-            let theme = state.theme.clone();
-            let wallpaper_config = state.wallpaper.clone();
-            let wallpaper_preview = state.wallpaper_preview.clone();
-            let wallpaper_library = state.wallpaper_library.clone();
-            let privileged_app_ids = state.privileged_app_ids.clone();
-            *state = DesktopState::from_snapshot(snapshot);
-            state.theme = theme;
-            state.wallpaper = wallpaper_config;
-            state.wallpaper_preview = wallpaper_preview;
-            state.wallpaper_library = wallpaper_library;
-            state.privileged_app_ids = privileged_app_ids;
-            let max_restore = state.preferences.max_restore_windows;
-            if state.windows.len() > max_restore {
-                state.windows.truncate(max_restore);
+        DesktopAction::CompleteBootHydration {
+            snapshot,
+            snapshot_revision,
+            theme,
+            wallpaper,
+            privileged_app_ids,
+            deep_link,
+        } => {
+            if let Some(snapshot) = snapshot {
+                restore_snapshot(
+                    state,
+                    interaction,
+                    snapshot,
+                    HydrationMode::BootRestore,
+                    snapshot_revision,
+                    &mut effects,
+                );
+            } else {
+                *interaction = InteractionState::default();
+                state.layout_revision = snapshot_revision;
             }
-            normalize_window_stack(state);
-            if matches!(mode, HydrationMode::BootRestore) {
-                for window in state.windows.iter_mut() {
-                    record_window_lifecycle_by_id(window, AppLifecycleEvent::Mounted);
-                    effects.push(RuntimeEffect::DispatchLifecycle {
-                        window_id: window.id,
-                        event: AppLifecycleEvent::Mounted,
-                    });
-                }
-                if let Some(focused) = state.focused_window_id() {
-                    record_window_lifecycle(state, focused, AppLifecycleEvent::Focused);
-                    effects.push(RuntimeEffect::DispatchLifecycle {
-                        window_id: focused,
-                        event: AppLifecycleEvent::Focused,
-                    });
-                }
+            if let Some(theme) = theme {
+                state.theme = theme;
             }
-        }
-        DesktopAction::HydratePolicyOverlay { privileged_app_ids } => {
+            if let Some(wallpaper) = wallpaper {
+                state.wallpaper = wallpaper;
+                state.wallpaper_preview = None;
+            }
             state.privileged_app_ids = privileged_app_ids.into_iter().collect();
-        }
-        DesktopAction::ApplyDeepLink { deep_link } => {
-            effects.push(RuntimeEffect::ParseAndOpenDeepLink(deep_link));
-        }
-        DesktopAction::BootHydrationComplete => {
+            if let Some(deep_link) = deep_link {
+                apply_deep_link_targets(state, interaction, deep_link, &mut effects)?;
+            }
             state.boot_hydrated = true;
         }
+        DesktopAction::HydrateSnapshot {
+            snapshot,
+            mode,
+            revision,
+        } => {
+            if revision.is_some_and(|incoming| {
+                state
+                    .layout_revision
+                    .is_some_and(|current| incoming <= current)
+            }) {
+                return Ok(effects);
+            }
+            restore_snapshot(state, interaction, snapshot, mode, revision, &mut effects);
+        }
+        DesktopAction::ApplyDeepLink { deep_link } => {
+            apply_deep_link_targets(state, interaction, deep_link, &mut effects)?;
+        }
+        DesktopAction::RecordAppliedRevision { domain, revision } => match domain {
+            SyncDomain::Layout => state.layout_revision = Some(revision),
+            SyncDomain::Theme => state.theme_revision = Some(revision),
+            SyncDomain::Wallpaper => state.wallpaper_revision = Some(revision),
+        },
         DesktopAction::SetCurrentWallpaper { .. }
         | DesktopAction::PreviewWallpaper { .. }
         | DesktopAction::ApplyWallpaperPreview
@@ -1131,10 +1175,129 @@ pub fn build_open_request_from_deeplink(target: DeepLinkOpenTarget) -> OpenWindo
     }
 }
 
+fn restore_snapshot(
+    state: &mut DesktopState,
+    interaction: &mut InteractionState,
+    snapshot: DesktopSnapshot,
+    mode: HydrationMode,
+    revision: Option<u64>,
+    effects: &mut Vec<RuntimeEffect>,
+) {
+    let theme = state.theme.clone();
+    let wallpaper_config = state.wallpaper.clone();
+    let wallpaper_preview = state.wallpaper_preview.clone();
+    let wallpaper_library = state.wallpaper_library.clone();
+    let privileged_app_ids = state.privileged_app_ids.clone();
+    let theme_revision = state.theme_revision;
+    let wallpaper_revision = state.wallpaper_revision;
+    *state = DesktopState::from_snapshot(snapshot);
+    *interaction = InteractionState::default();
+    state.theme = theme;
+    state.wallpaper = wallpaper_config;
+    state.wallpaper_preview = wallpaper_preview;
+    state.wallpaper_library = wallpaper_library;
+    state.privileged_app_ids = privileged_app_ids;
+    state.theme_revision = theme_revision;
+    state.wallpaper_revision = wallpaper_revision;
+    state.layout_revision = revision;
+    let max_restore = state.preferences.max_restore_windows;
+    if state.windows.len() > max_restore {
+        state.windows.truncate(max_restore);
+    }
+    normalize_window_stack(state);
+    if matches!(mode, HydrationMode::BootRestore) {
+        for window in state.windows.iter_mut() {
+            record_window_lifecycle_by_id(window, AppLifecycleEvent::Mounted);
+            effects.push(RuntimeEffect::DispatchLifecycle {
+                window_id: window.id,
+                event: AppLifecycleEvent::Mounted,
+            });
+        }
+        if let Some(focused) = state.focused_window_id() {
+            record_window_lifecycle(state, focused, AppLifecycleEvent::Focused);
+            effects.push(RuntimeEffect::DispatchLifecycle {
+                window_id: focused,
+                event: AppLifecycleEvent::Focused,
+            });
+        }
+    }
+}
+
+fn apply_deep_link_targets(
+    state: &mut DesktopState,
+    interaction: &mut InteractionState,
+    deep_link: DeepLinkState,
+    effects: &mut Vec<RuntimeEffect>,
+) -> Result<(), ReducerError> {
+    for target in deep_link.open {
+        if deep_link_target_satisfied(state, &target) {
+            continue;
+        }
+
+        let nested = match target {
+            DeepLinkOpenTarget::App(app_id) => reduce_desktop(
+                state,
+                interaction,
+                DesktopAction::ActivateApp {
+                    app_id,
+                    viewport: None,
+                },
+            )?,
+            other => reduce_desktop(
+                state,
+                interaction,
+                DesktopAction::OpenWindow(build_open_request_from_deeplink(other)),
+            )?,
+        };
+        effects.extend(nested);
+    }
+
+    Ok(())
+}
+
+fn deep_link_target_satisfied(state: &DesktopState, target: &DeepLinkOpenTarget) -> bool {
+    match target {
+        DeepLinkOpenTarget::App(app_id) => {
+            state.windows.iter().any(|window| window.app_id == *app_id)
+        }
+        DeepLinkOpenTarget::NotesSlug(slug) => {
+            let persist_key = format!("notes:{slug}");
+            state
+                .windows
+                .iter()
+                .any(|window| window.persist_key.as_deref() == Some(persist_key.as_str()))
+        }
+        DeepLinkOpenTarget::ProjectSlug(slug) => {
+            let persist_key = format!("projects:{slug}");
+            state
+                .windows
+                .iter()
+                .any(|window| window.persist_key.as_deref() == Some(persist_key.as_str()))
+        }
+    }
+}
+
 fn next_window_id(state: &mut DesktopState) -> WindowId {
     let id = WindowId(state.next_window_id);
     state.next_window_id = state.next_window_id.saturating_add(1);
     id
+}
+
+fn clear_interaction_for_window(interaction: &mut InteractionState, window_id: WindowId) {
+    if interaction
+        .dragging
+        .as_ref()
+        .is_some_and(|session| session.window_id == window_id)
+    {
+        interaction.dragging = None;
+    }
+    if interaction
+        .resizing
+        .as_ref()
+        .is_some_and(|session| session.window_id == window_id)
+    {
+        interaction.resizing = None;
+    }
 }
 
 fn preferred_window_for_app(state: &DesktopState, app_id: &ApplicationId) -> Option<WindowId> {
@@ -2052,6 +2215,7 @@ mod tests {
             DesktopAction::HydrateSnapshot {
                 snapshot,
                 mode: HydrationMode::BootRestore,
+                revision: None,
             },
         )
         .expect("hydrate snapshot");
@@ -2090,11 +2254,137 @@ mod tests {
             DesktopAction::HydrateSnapshot {
                 snapshot,
                 mode: HydrationMode::SyncRefresh,
+                revision: Some(7),
             },
         )
         .expect("sync hydrate");
 
         assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn stale_sync_snapshot_is_ignored() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let first = open(
+            &mut state,
+            &mut interaction,
+            ApplicationId::trusted("system.settings"),
+        );
+        state.layout_revision = Some(12);
+
+        let mut snapshot = DesktopState::default().snapshot();
+        snapshot.windows = vec![WindowRecord {
+            id: WindowId(9),
+            app_id: ApplicationId::trusted("system.control-center"),
+            title: "Control Center".to_string(),
+            icon_id: "home".to_string(),
+            rect: WindowRect::default(),
+            restore_rect: None,
+            z_index: 1,
+            is_focused: true,
+            minimized: false,
+            maximized: false,
+            suspended: false,
+            flags: WindowFlags::default(),
+            persist_key: None,
+            app_state: Value::Null,
+            launch_params: Value::Null,
+            last_lifecycle_event: None,
+        }];
+
+        let effects = reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::HydrateSnapshot {
+                snapshot,
+                mode: HydrationMode::SyncRefresh,
+                revision: Some(11),
+            },
+        )
+        .expect("stale hydrate should not error");
+
+        assert!(effects.is_empty());
+        assert_eq!(state.windows.len(), 1);
+        assert_eq!(state.windows[0].id, first);
+        assert_eq!(state.layout_revision, Some(12));
+    }
+
+    #[test]
+    fn complete_boot_hydration_augments_without_duplicate_deep_link_open() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let mut snapshot = DesktopState::default().snapshot();
+        snapshot.windows = vec![WindowRecord {
+            id: WindowId(4),
+            app_id: ApplicationId::trusted("system.settings"),
+            title: "Settings - Notes roadmap".to_string(),
+            icon_id: "settings".to_string(),
+            rect: WindowRect::default(),
+            restore_rect: None,
+            z_index: 1,
+            is_focused: true,
+            minimized: false,
+            maximized: false,
+            suspended: false,
+            flags: WindowFlags::default(),
+            persist_key: Some("notes:roadmap".to_string()),
+            app_state: Value::Null,
+            launch_params: json!({ "section": "personalize", "note_slug": "roadmap" }),
+            last_lifecycle_event: None,
+        }];
+
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::CompleteBootHydration {
+                snapshot: Some(snapshot),
+                snapshot_revision: Some(21),
+                theme: None,
+                wallpaper: None,
+                privileged_app_ids: Vec::new(),
+                deep_link: Some(DeepLinkState {
+                    open: vec![DeepLinkOpenTarget::NotesSlug("roadmap".to_string())],
+                }),
+            },
+        )
+        .expect("boot hydration");
+
+        assert_eq!(state.windows.len(), 1);
+        assert_eq!(state.layout_revision, Some(21));
+        assert!(state.boot_hydrated);
+    }
+
+    #[test]
+    fn complete_boot_hydration_applies_unsatisfied_deep_link_after_restore() {
+        let mut state = DesktopState::default();
+        let mut interaction = InteractionState::default();
+        let snapshot = DesktopState::default().snapshot();
+
+        reduce_desktop(
+            &mut state,
+            &mut interaction,
+            DesktopAction::CompleteBootHydration {
+                snapshot: Some(snapshot),
+                snapshot_revision: Some(30),
+                theme: None,
+                wallpaper: None,
+                privileged_app_ids: Vec::new(),
+                deep_link: Some(DeepLinkState {
+                    open: vec![DeepLinkOpenTarget::App(ApplicationId::trusted(
+                        "system.terminal",
+                    ))],
+                }),
+            },
+        )
+        .expect("boot hydration");
+
+        assert_eq!(state.windows.len(), 1);
+        assert_eq!(
+            state.windows[0].app_id,
+            ApplicationId::trusted("system.terminal")
+        );
+        assert!(state.boot_hydrated);
     }
 
     #[test]
@@ -2319,8 +2609,13 @@ mod tests {
         reduce_desktop(
             &mut state,
             &mut interaction,
-            DesktopAction::HydratePolicyOverlay {
+            DesktopAction::CompleteBootHydration {
+                snapshot: None,
+                snapshot_revision: None,
+                theme: None,
+                wallpaper: None,
                 privileged_app_ids: vec!["system.terminal".to_string()],
+                deep_link: None,
             },
         )
         .expect("hydrate policy overlay");

--- a/ui/crates/desktop_runtime/src/reducer/appearance.rs
+++ b/ui/crates/desktop_runtime/src/reducer/appearance.rs
@@ -34,12 +34,35 @@ pub(super) fn reduce_appearance_action(
         DesktopAction::ClearWallpaperPreview => {
             state.wallpaper_preview = None;
         }
-        DesktopAction::HydrateTheme { theme } => {
+        DesktopAction::HydrateTheme { theme, revision } => {
+            if revision.is_some_and(|incoming| {
+                state
+                    .theme_revision
+                    .is_some_and(|current| incoming <= current)
+            }) {
+                return Ok(true);
+            }
             state.theme = theme.clone();
+            if let Some(revision) = revision {
+                state.theme_revision = Some(*revision);
+            }
         }
-        DesktopAction::HydrateWallpaper { wallpaper } => {
+        DesktopAction::HydrateWallpaper {
+            wallpaper,
+            revision,
+        } => {
+            if revision.is_some_and(|incoming| {
+                state
+                    .wallpaper_revision
+                    .is_some_and(|current| incoming <= current)
+            }) {
+                return Ok(true);
+            }
             state.wallpaper = canonicalize_wallpaper_config(wallpaper.clone());
             state.wallpaper_preview = None;
+            if let Some(revision) = revision {
+                state.wallpaper_revision = Some(*revision);
+            }
         }
         DesktopAction::WallpaperLibraryLoaded { snapshot } => {
             state.wallpaper_library = wallpaper::merged_wallpaper_library(snapshot);

--- a/ui/crates/desktop_runtime/src/runtime_context.rs
+++ b/ui/crates/desktop_runtime/src/runtime_context.rs
@@ -12,7 +12,7 @@ use crate::{
     app_runtime::{sync_runtime_sessions, AppRuntimeState},
     apps, effect_executor,
     host::DesktopHostContext,
-    model::{DesktopState, InteractionState},
+    model::{DeepLinkState, DesktopState, InteractionState},
     reducer::{reduce_desktop, DesktopAction, RuntimeEffect},
     shell,
 };
@@ -45,11 +45,14 @@ impl DesktopRuntimeContext {
     }
 }
 
-fn install_runtime_orchestration(runtime: DesktopRuntimeContext) {
+fn install_runtime_orchestration(
+    runtime: DesktopRuntimeContext,
+    initial_deep_link: Option<DeepLinkState>,
+) {
     runtime
         .host
         .get_value()
-        .install_boot_hydration(runtime.dispatch);
+        .install_boot_hydration(runtime.dispatch, initial_deep_link);
     std::mem::forget(shell::register_builtin_commands(runtime));
     effect_executor::install(runtime);
 }
@@ -59,6 +62,8 @@ fn install_runtime_orchestration(runtime: DesktopRuntimeContext) {
 pub fn DesktopProvider(
     /// Injected browser or desktop host bundle assembled by the entry layer.
     host_services: HostServices,
+    /// URL intent captured by the browser entrypoint before runtime boot begins.
+    initial_deep_link: Option<DeepLinkState>,
     children: Children,
 ) -> impl IntoView {
     let host = store_value(DesktopHostContext::new(host_services));
@@ -125,7 +130,7 @@ pub fn DesktopProvider(
 
     provide_context(runtime.clone());
 
-    install_runtime_orchestration(runtime);
+    install_runtime_orchestration(runtime, initial_deep_link);
 
     children().into_view()
 }

--- a/ui/crates/platform_host_web/src/cross_context.rs
+++ b/ui/crates/platform_host_web/src/cross_context.rs
@@ -2,25 +2,36 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Shell-level events shared across browser tabs when `BroadcastChannel` is available.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Browser state domains that participate in shell synchronization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum ShellSyncEvent {
+pub enum ShellSyncKind {
     /// Theme or accessibility preferences changed.
-    ThemeChanged,
+    Theme,
     /// Wallpaper selection or wallpaper metadata changed.
-    WallpaperChanged,
-    /// Desktop layout state was durably persisted and other contexts should rehydrate.
-    LayoutChanged,
+    Wallpaper,
+    /// Desktop layout state changed.
+    Layout,
 }
 
-#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Shell-sync event envelope exchanged across same-origin browser contexts.
+pub struct ShellSyncEvent {
+    /// Domain affected by the change.
+    pub kind: ShellSyncKind,
+    /// Stable sender identity for the current browser context.
+    pub sender_id: String,
+    /// Monotonic revision for stale-event suppression.
+    pub revision: u64,
+}
+
 impl ShellSyncEvent {
-    fn as_message(&self) -> &'static str {
-        match self {
-            Self::ThemeChanged => "theme-changed",
-            Self::WallpaperChanged => "wallpaper-changed",
-            Self::LayoutChanged => "layout-changed",
+    /// Creates a new event using the current browser context sender identity.
+    pub fn new(kind: ShellSyncKind, revision: u64) -> Self {
+        Self {
+            kind,
+            sender_id: shell_sync_sender_id(),
+            revision,
         }
     }
 }
@@ -42,8 +53,51 @@ pub fn broadcast_channel_supported() -> bool {
     }
 }
 
+/// Returns the stable sender identity for this browser context.
+pub fn shell_sync_sender_id() -> String {
+    #[cfg(target_arch = "wasm32")]
+    {
+        thread_local! {
+            static SHELL_SYNC_SENDER_ID: String = format!(
+                "origin-shell-{}",
+                platform_host::next_monotonic_timestamp_ms()
+            );
+        }
+
+        SHELL_SYNC_SENDER_ID.with(Clone::clone)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        "origin-shell-test".to_string()
+    }
+}
+
+/// Returns whether an incoming sync event should be applied locally.
+pub fn should_apply_shell_sync_event(
+    incoming: &ShellSyncEvent,
+    current_sender_id: &str,
+    last_applied_revision: Option<u64>,
+) -> bool {
+    if incoming.sender_id == current_sender_id {
+        return false;
+    }
+
+    last_applied_revision.is_none_or(|current| incoming.revision > current)
+}
+
+/// Encodes an event into a transport payload.
+pub fn encode_shell_sync_event(event: &ShellSyncEvent) -> Result<String, String> {
+    serde_json::to_string(event).map_err(|error| error.to_string())
+}
+
+/// Decodes a transport payload into a typed sync event.
+pub fn decode_shell_sync_event(raw: &str) -> Option<ShellSyncEvent> {
+    serde_json::from_str(raw).ok()
+}
+
 /// Publishes a shell-sync event to other same-origin browser contexts.
-pub fn publish_shell_sync_event(event: ShellSyncEvent) {
+pub fn publish_shell_sync_event(event: &ShellSyncEvent) {
     #[cfg(target_arch = "wasm32")]
     {
         if !broadcast_channel_supported() {
@@ -51,7 +105,9 @@ pub fn publish_shell_sync_event(event: ShellSyncEvent) {
         }
 
         if let Ok(channel) = web_sys::BroadcastChannel::new("origin-os-shell-sync") {
-            let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(event.as_message()));
+            if let Ok(message) = encode_shell_sync_event(event) {
+                let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&message));
+            }
             channel.close();
         }
     }
@@ -59,5 +115,53 @@ pub fn publish_shell_sync_event(event: ShellSyncEvent) {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let _ = event;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignores_self_originated_events() {
+        let event = ShellSyncEvent {
+            kind: ShellSyncKind::Layout,
+            sender_id: "tab-a".to_string(),
+            revision: 10,
+        };
+        assert!(!should_apply_shell_sync_event(&event, "tab-a", Some(9)));
+    }
+
+    #[test]
+    fn ignores_stale_events() {
+        let event = ShellSyncEvent {
+            kind: ShellSyncKind::Theme,
+            sender_id: "tab-b".to_string(),
+            revision: 9,
+        };
+        assert!(!should_apply_shell_sync_event(&event, "tab-a", Some(9)));
+        assert!(!should_apply_shell_sync_event(&event, "tab-a", Some(10)));
+    }
+
+    #[test]
+    fn accepts_newer_cross_context_events() {
+        let event = ShellSyncEvent {
+            kind: ShellSyncKind::Wallpaper,
+            sender_id: "tab-b".to_string(),
+            revision: 11,
+        };
+        assert!(should_apply_shell_sync_event(&event, "tab-a", Some(10)));
+    }
+
+    #[test]
+    fn event_round_trip_is_stable() {
+        let event = ShellSyncEvent {
+            kind: ShellSyncKind::Layout,
+            sender_id: "tab-a".to_string(),
+            revision: 42,
+        };
+        let encoded = encode_shell_sync_event(&event).expect("encode shell sync event");
+        let decoded = decode_shell_sync_event(&encoded).expect("decode shell sync event");
+        assert_eq!(decoded, event);
     }
 }

--- a/ui/crates/platform_host_web/src/lib.rs
+++ b/ui/crates/platform_host_web/src/lib.rs
@@ -40,7 +40,10 @@ pub use adapters::{
 };
 pub use cache::cache_api::WebContentCache;
 pub use cache::tauri_cache_api::TauriContentCache;
-pub use cross_context::{broadcast_channel_supported, publish_shell_sync_event, ShellSyncEvent};
+pub use cross_context::{
+    broadcast_channel_supported, decode_shell_sync_event, publish_shell_sync_event,
+    shell_sync_sender_id, should_apply_shell_sync_event, ShellSyncEvent, ShellSyncKind,
+};
 pub use external_url::{TauriExternalUrlService, WebExternalUrlService};
 pub use fs::explorer::{TauriExplorerFsService, WebExplorerFsService};
 pub use notifications::{TauriNotificationService, WebNotificationService};

--- a/ui/crates/site/src/web_app.rs
+++ b/ui/crates/site/src/web_app.rs
@@ -8,6 +8,10 @@ use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
 use platform_host_web::build_host_services;
+#[cfg(target_arch = "wasm32")]
+use platform_host_web::{
+    decode_shell_sync_event, shell_sync_sender_id, should_apply_shell_sync_event, ShellSyncKind,
+};
 
 use crate::browser_navigation::{current_browser_route, BrowserRoute};
 
@@ -57,11 +61,15 @@ pub fn SiteApp() -> impl IntoView {
 /// Default route that mounts the desktop runtime provider and shell.
 pub fn DesktopEntry() -> impl IntoView {
     let host_services = build_host_services();
+    let initial_deep_link = match current_browser_route() {
+        Some(BrowserRoute::Shell(Some(deep_link))) if !deep_link.open.is_empty() => Some(deep_link),
+        _ => None,
+    };
     if let Some(browser_e2e) = current_browser_e2e_config() {
         provide_context::<BrowserE2eConfig>(browser_e2e);
     }
     view! {
-        <DesktopProvider host_services>
+        <DesktopProvider host_services initial_deep_link=initial_deep_link>
             <DesktopUrlBoot />
             <BrowserRuntimeEnhancements />
             <BrowserShellSync />
@@ -75,6 +83,9 @@ fn DesktopUrlBoot() -> impl IntoView {
     let runtime = use_desktop_runtime();
 
     create_effect(move |_| {
+        if !runtime.state.get().boot_hydrated {
+            return;
+        }
         if let Some(BrowserRoute::Shell(Some(deep_link))) = current_browser_route() {
             if !deep_link.open.is_empty() {
                 runtime.dispatch_action(DesktopAction::ApplyDeepLink { deep_link });
@@ -96,7 +107,8 @@ fn BrowserRuntimeEnhancements() -> impl IntoView {
 
 #[component]
 fn BrowserShellSync() -> impl IntoView {
-    let _runtime = use_desktop_runtime();
+    #[cfg(target_arch = "wasm32")]
+    let runtime = use_desktop_runtime();
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -105,7 +117,7 @@ fn BrowserShellSync() -> impl IntoView {
         };
         use wasm_bindgen::{closure::Closure, JsCast};
 
-        let host = _runtime.host.get_value();
+        let host = runtime.host.get_value();
         create_effect(move |_| {
             if !platform_host_web::broadcast_channel_supported() {
                 return;
@@ -114,37 +126,69 @@ fn BrowserShellSync() -> impl IntoView {
             let Ok(channel) = web_sys::BroadcastChannel::new("origin-os-shell-sync") else {
                 return;
             };
-            let runtime = _runtime.clone();
+            let runtime = runtime.clone();
             let host = host.clone();
+            let sender_id = shell_sync_sender_id();
 
             let callback = Closure::<dyn FnMut(web_sys::MessageEvent)>::wrap(Box::new(
                 move |event: web_sys::MessageEvent| {
                     let Some(message) = event.data().as_string() else {
                         return;
                     };
+                    let Some(sync_event) = decode_shell_sync_event(&message) else {
+                        return;
+                    };
+                    if !runtime.state.get_untracked().boot_hydrated {
+                        return;
+                    }
 
-                    match message.as_str() {
-                        "theme-changed" => {
+                    match sync_event.kind {
+                        ShellSyncKind::Theme => {
+                            if !should_apply_shell_sync_event(
+                                &sync_event,
+                                &sender_id,
+                                runtime.state.get_untracked().theme_revision,
+                            ) {
+                                return;
+                            }
                             let runtime = runtime.clone();
                             let host = host.clone();
                             leptos::spawn_local(async move {
                                 if let Some(theme) = load_theme(&host).await {
-                                    runtime.dispatch_action(DesktopAction::HydrateTheme { theme });
+                                    runtime.dispatch_action(DesktopAction::HydrateTheme {
+                                        theme,
+                                        revision: Some(sync_event.revision),
+                                    });
                                 }
                             });
                         }
-                        "wallpaper-changed" => {
+                        ShellSyncKind::Wallpaper => {
+                            if !should_apply_shell_sync_event(
+                                &sync_event,
+                                &sender_id,
+                                runtime.state.get_untracked().wallpaper_revision,
+                            ) {
+                                return;
+                            }
                             let runtime = runtime.clone();
                             let host = host.clone();
                             leptos::spawn_local(async move {
                                 if let Some(wallpaper) = load_wallpaper(&host).await {
                                     runtime.dispatch_action(DesktopAction::HydrateWallpaper {
                                         wallpaper,
+                                        revision: Some(sync_event.revision),
                                     });
                                 }
                             });
                         }
-                        "layout-changed" => {
+                        ShellSyncKind::Layout => {
+                            if !should_apply_shell_sync_event(
+                                &sync_event,
+                                &sender_id,
+                                runtime.state.get_untracked().layout_revision,
+                            ) {
+                                return;
+                            }
                             let runtime = runtime.clone();
                             let host = host.clone();
                             leptos::spawn_local(async move {
@@ -152,11 +196,11 @@ fn BrowserShellSync() -> impl IntoView {
                                     runtime.dispatch_action(DesktopAction::HydrateSnapshot {
                                         snapshot,
                                         mode: HydrationMode::SyncRefresh,
+                                        revision: Some(sync_event.revision),
                                     });
                                 }
                             });
                         }
-                        _ => {}
                     }
                 },
             ));

--- a/ui/e2e/wasm_sri_smoke.cjs
+++ b/ui/e2e/wasm_sri_smoke.cjs
@@ -122,6 +122,7 @@ async function main() {
   const browserTargets = [
     ["chromium", playwright.chromium],
     ["firefox", playwright.firefox],
+    ["webkit", playwright.webkit],
   ];
   const browsers = [];
   for (const [name, browserType] of browserTargets) {

--- a/ui/logic_audit.md
+++ b/ui/logic_audit.md
@@ -1,0 +1,120 @@
+# Deterministic UI Shell Logic Audit
+
+## Current Runtime Graph Before Remediation
+
+```mermaid
+flowchart TD
+    A["DesktopProvider mount"] --> B["install_boot_hydration"]
+    B --> C["load legacy snapshot"]
+    C --> D["optional HydrateSnapshot(BootRestore) from legacy"]
+    D --> E["load theme and wallpaper prefs"]
+    E --> F["load durable snapshot"]
+    F --> G["optional HydrateSnapshot(BootRestore) from durable"]
+    F --> H["or migrate legacy snapshot when restore_on_boot=false"]
+    G --> I["BootHydrationComplete"]
+    H --> I
+    A --> J["site::DesktopUrlBoot dispatches ApplyDeepLink independently"]
+    A --> K["BrowserShellSync listens to BroadcastChannel independently"]
+```
+
+## Defects
+
+### UI-BOOT-01
+- Files and symbols:
+  - `ui/crates/desktop_runtime/src/host/boot.rs`
+  - `install_boot_hydration`
+- Root cause:
+  Boot hydration loaded legacy and durable snapshots independently and dispatched both restore actions during one session.
+- Pre-fix failure mode:
+  A runtime session could restore the same layout twice, replay lifecycle twice, and race with later boot effects.
+- Implemented correction:
+  Replaced the multi-dispatch boot path with a typed `BootHydrationPlan` and a single reducer action, `CompleteBootHydration`, that resolves authority, migration, restore, and deep-link augmentation once.
+- Residual risk:
+  None in reducer-covered paths. Corrupt persisted payloads still fall back to safe non-restore behavior.
+
+### UI-BOOT-02
+- Files and symbols:
+  - `ui/crates/desktop_runtime/src/host/boot.rs`
+  - `ui/crates/desktop_runtime/src/persistence.rs`
+  - `resolve_boot_hydration_plan`
+  - `load_durable_boot_snapshot_record`
+- Root cause:
+  Durable precedence was only used for preference resolution. Legacy migration could be skipped or delayed depending on restore ordering.
+- Pre-fix failure mode:
+  Legacy-only state could avoid durable migration during restore-on-boot, and durable+legacy state could still hydrate legacy first.
+- Implemented correction:
+  Durable snapshot envelope is authoritative when present. Legacy snapshot is compatibility input only. Legacy-only state is migrated once before any authoritative hydrate and is still migrated when restore-on-boot is disabled.
+- Residual risk:
+  If durable save fails during legacy migration, the session still hydrates from the legacy snapshot once and logs the persistence failure.
+
+### UI-DEEPLINK-01
+- Files and symbols:
+  - `ui/crates/site/src/web_app.rs`
+  - `ui/crates/desktop_runtime/src/runtime_context.rs`
+  - `ui/crates/desktop_runtime/src/reducer.rs`
+  - `CompleteBootHydration`
+  - `apply_deep_link_targets`
+- Root cause:
+  URL deep-link application ran in a separate browser effect with no boot gate and no merge semantics relative to restore state.
+- Pre-fix failure mode:
+  Async ordering could change whether a deep link opened a duplicate window, raced with restore, or was applied before boot completion.
+- Implemented correction:
+  The site entrypoint captures the initial URL intent and passes it into `DesktopProvider`. Boot hydration applies it inside the atomic reducer transition after restore using augment semantics and duplicate suppression.
+- Residual risk:
+  Live URL changes after initial mount still rely on the browser effect path, but the reducer now deduplicates satisfied targets and waits for `boot_hydrated`.
+
+### UI-SYNC-01
+- Files and symbols:
+  - `ui/crates/platform_host_web/src/cross_context.rs`
+  - `ui/crates/site/src/web_app.rs`
+  - `ui/crates/desktop_runtime/src/host/persistence_effects.rs`
+- Root cause:
+  `BroadcastChannel` messages were raw strings with no sender identity or revision metadata.
+- Pre-fix failure mode:
+  Same-tab loops and stale-tab rehydrates could replay older theme, wallpaper, or layout state into a newer in-memory session.
+- Implemented correction:
+  Replaced string messages with typed `ShellSyncEvent { kind, sender_id, revision }`, added sender identity, added monotonic revision checks, and ignored sync messages until boot hydration completes.
+- Residual risk:
+  Theme and wallpaper revisions are host-generated monotonic values rather than durable envelope timestamps because those domains remain stored in typed prefs rather than durable app-state envelopes.
+
+### UI-RESTORE-01
+- Files and symbols:
+  - `ui/crates/desktop_runtime/src/model.rs`
+  - `DesktopState::from_snapshot`
+- Root cause:
+  Snapshot restore trusted persisted modal and focus state without rebuilding runtime invariants.
+- Pre-fix failure mode:
+  Orphaned modal children, ambiguous focus ownership, and stale next-window ids could survive restore.
+- Implemented correction:
+  Restore now recomputes focus, `active_modal`, `next_window_id`, and transient runtime-only fields. Orphaned modal children are dropped deterministically.
+- Residual risk:
+  Multi-modal corruption is normalized to a single active modal path rather than preserved exactly.
+
+### UI-REDUCER-01
+- Files and symbols:
+  - `ui/crates/desktop_runtime/src/reducer.rs`
+  - `CloseWindow`
+  - `HydrateSnapshot`
+  - `RecordAppliedRevision`
+- Root cause:
+  Transition safety around hydrate and close paths did not clear transient interaction state or reject stale revisions.
+- Pre-fix failure mode:
+  Closed windows could leave drag/resize state behind, and sync refresh could overwrite newer runtime state with older persisted snapshots.
+- Implemented correction:
+  Close and hydrate paths now clear transient interaction state. Sync hydration rejects non-newer revisions, and local persistence advances applied revisions before broadcasting.
+- Residual risk:
+  None observed in current tests.
+
+## Patch Summary
+- Added atomic boot completion and typed boot planning in `desktop_runtime`.
+- Added durable snapshot revision loading and deterministic legacy migration.
+- Moved deep-link application into the reducer with restore-aware duplicate suppression.
+- Added revision-aware, sender-aware browser sync in `platform_host_web`.
+- Rebuilt restore invariants in `DesktopState::from_snapshot`.
+- Extended automated browser smoke coverage to Chromium, Firefox, and WebKit.
+
+## Test Additions
+- Boot planner tests for durable precedence, legacy migration with restore disabled, and single-pass legacy restore.
+- Model tests for orphaned modal rejection and valid modal reconstruction.
+- Reducer tests for stale sync rejection and deterministic boot deep-link augmentation.
+- Cross-context tests for self-event ignore, stale-event ignore, and typed event round-trip.

--- a/ui/migration_note.md
+++ b/ui/migration_note.md
@@ -1,0 +1,11 @@
+# Desktop Snapshot Migration Note
+
+- Durable desktop state in namespace `system.desktop` is authoritative for boot restore.
+- Legacy browser snapshot data is compatibility input only.
+- When both durable and legacy state exist, only the durable snapshot is eligible for restore.
+- When only legacy state exists, the runtime migrates it into durable storage once and then treats that migrated representation as authoritative for any restore in the same session.
+- When `restore_on_boot` is disabled, the runtime still performs the one-way legacy-to-durable migration when legacy data exists, but it does not hydrate layout from either source.
+- Migration is deterministic and repeat-safe:
+  - it never prefers legacy over an existing durable snapshot;
+  - it only writes the typed durable `system.desktop` envelope;
+  - rerunning the migration path with unchanged legacy input yields the same durable payload shape, with only the monotonic envelope timestamp differing.

--- a/ui/verification_report.md
+++ b/ui/verification_report.md
@@ -1,0 +1,156 @@
+# UI Shell Verification Report
+
+## Commands Executed
+
+| Command | Result |
+| --- | --- |
+| `cargo check -p desktop_runtime` | PASS |
+| `cargo check -p site` | PASS |
+| `cargo check -p desktop_tauri` | PASS |
+| `cargo test -p desktop_runtime` | PASS |
+| `cargo test -p platform_host_web` | PASS |
+| `cargo test -p site` | PASS |
+| `cargo ui-build` | PASS |
+| `cargo verify-ui` | PASS |
+| `cargo xtask ui-hardening` | PASS |
+
+## Command Transcript Summary
+
+### `cargo check -p desktop_runtime`
+- Result: pass
+- Notable output:
+  - `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 1.22s`
+
+### `cargo check -p site`
+- Result: pass
+- Notable output:
+  - `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 0.69s`
+
+### `cargo check -p desktop_tauri`
+- Result: pass
+- Notable output:
+  - `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 31.14s`
+
+### `cargo test -p desktop_runtime`
+- Result: pass
+- Coverage relevant to this remediation:
+  - boot planner precedence and migration
+  - orphaned modal restore rejection
+  - modal reconstruction
+  - stale sync snapshot rejection
+  - deterministic boot deep-link augmentation
+
+### `cargo test -p platform_host_web`
+- Result: pass
+- Coverage relevant to this remediation:
+  - self-originated sync ignore
+  - stale sync ignore
+  - newer sync acceptance
+  - typed event round-trip
+
+### `cargo test -p site`
+- Result: pass
+- Coverage relevant to this remediation:
+  - browser route parsing
+  - compatibility deep-link routing
+  - browser asset-path handling
+
+### `cargo ui-build`
+- Result: pass
+- Notable output:
+  - `Running 'target/debug/xtask ui build'`
+  - `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 7.56s`
+
+### `cargo verify-ui`
+- Result: pass
+- Notable output:
+  - `Running 'target/debug/xtask verify profile ui'`
+  - package checks, tests, preview smoke path, and browser build completed without failures
+
+### `cargo xtask ui-hardening`
+- Result: pass
+- Generated report:
+  - `build/wasm-hardening/remediation-report.md`
+- Final status:
+  - `pipeline status: HARDENED`
+  - `byte-identical result: PASS`
+  - browser matrix `PASS`
+
+## Artifact Inventory
+
+### Canonical Hardened Browser Artifact Set
+- Path: `build/wasm-hardening/build-b`
+- Files:
+  - `icon.png`
+  - `index.html`
+  - `manifest.webmanifest`
+  - `site_app-4a493b95f643e7b.js`
+  - `site_app-4a493b95f643e7b_bg.wasm`
+  - `snippets/platform_host_web-a3dd707719cd2672/inline0.js`
+  - `sw.js`
+  - `wallpapers/aurora-flow-poster.svg`
+  - `wallpapers/aurora-flow.svg`
+  - `wallpapers/catalog.toml`
+  - `wallpapers/city-lights.svg`
+  - `wallpapers/cloud-bands.svg`
+  - `wallpapers/green-hills.svg`
+  - `wallpapers/paper-grid.svg`
+  - `wallpapers/rain-window-poster.svg`
+  - `wallpapers/rain-window.svg`
+  - `wallpapers/sunset-lake.svg`
+  - `wallpapers/teal-grid.svg`
+  - `wallpapers/teal-solid.svg`
+  - `wallpapers/woven-steel.svg`
+
+### Integrity Attributes
+- Verified from the hardening report:
+  - `/site_app-4a493b95f643e7b.js`
+  - `/snippets/platform_host_web-a3dd707719cd2672/inline0.js`
+  - `/site_app-4a493b95f643e7b_bg.wasm`
+- Result: all emitted integrity attributes matched independently computed digests.
+
+## Determinism Notes
+
+- `cargo xtask ui-hardening` performed two clean release browser builds and compared the full deployable artifact graph.
+- Clean build A: `build/wasm-hardening/build-a`
+- Clean build B: `build/wasm-hardening/build-b`
+- Result: byte-identical artifacts and identical generated HTML.
+- Output hash examples from the hardening report:
+  - `index.html`: `c996e370c4dfd59c7db3d4a8ba858040cddbfa4bb1bcdcae82b23aae5f088d5c`
+  - `site_app-4a493b95f643e7b.js`: `d953969d7c00cd3fb1c38778b436b60f02cbc1aed5e67aef5f6b31dabd10887f`
+  - `site_app-4a493b95f643e7b_bg.wasm`: `cdfddf6e3b1c59f820f251eb59cc8a8006ccecf2b1e4078803ab517f7fc9a15d`
+
+## Browser Validation
+
+### Automated
+- Source: `cargo xtask ui-hardening`
+- Node: `v25.8.0`
+- Results:
+  - Chromium: pass, no console errors, no request failures, no integrity failures, no WASM/module failures
+  - Firefox: pass, no console errors, no request failures, no integrity failures, no WASM/module failures
+  - WebKit: pass, no console errors, no request failures, no integrity failures, no WASM/module failures
+
+### Native Safari
+- Status: not separately instrumented in this environment
+- Note:
+  WebKit automation passed, which is a strong compatibility signal, but native Safari itself was not independently driven or observed through a dedicated automation surface in this run.
+
+## Defect Coverage Confirmation
+
+- Boot restore occurs exactly once per session:
+  verified by atomic boot hydration design and reducer tests.
+- Durable precedence and legacy migration:
+  verified by boot planner tests and durable revision loading.
+- Deep-link ordering:
+  verified by `CompleteBootHydration` reducer tests.
+- Same-context sync loop prevention:
+  verified by typed sender-aware `ShellSyncEvent` tests.
+- Stale sync rejection:
+  verified by reducer stale snapshot test and cross-context stale event test.
+- Restore invariants:
+  verified by snapshot normalization tests for modal and focus reconstruction.
+
+## Residual Risk Notes
+
+- Theme and wallpaper sync revisions are monotonic runtime-generated values rather than durable envelope timestamps because those values remain stored in typed prefs, not separate app-state envelopes.
+- Native Safari itself was not separately automated. WebKit passed, but a manual Safari confirmation remains advisable before a release that explicitly targets Safari.


### PR DESCRIPTION
## Summary
Harden the `origin/ui` shell runtime so boot hydration, legacy migration, deep-link application, and browser cross-context synchronization are deterministic and single-pass.

## Linked Issue
Closes #64

## Technical Changes
- add a typed boot planning path and atomic `CompleteBootHydration` reducer transition
- make durable `system.desktop` state authoritative and migrate legacy browser snapshots deterministically
- move deep-link application into reducer-owned transitions with restore-aware deduplication
- rebuild modal, focus, next-window-id, and transient interaction invariants during restore
- replace raw `BroadcastChannel` strings with typed sender-aware revision-bearing sync envelopes
- add regression tests and remediation evidence in `ui/logic_audit.md`, `ui/migration_note.md`, and `ui/verification_report.md`
- extend the browser smoke harness to include WebKit

## Testing Strategy
- `cargo check -p desktop_runtime`
- `cargo check -p site`
- `cargo check -p desktop_tauri`
- `cargo test -p desktop_runtime`
- `cargo test -p platform_host_web`
- `cargo test -p site`
- `cargo ui-build`
- `cargo verify-ui`
- `cargo xtask ui-hardening`

## Deployment Impact
Browser/WASM preview and the Tauri wrapper continue to compile, and the hardened browser pipeline now reports byte-identical clean builds with passing Chromium, Firefox, and WebKit smoke validation. Native Safari itself was not separately automated in this environment and is called out as a residual verification caveat in `ui/verification_report.md`.
