### PR TITLE
feat(ui): standardize observability and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,8 +1787,10 @@ dependencies = [
  "system_shell_contract",
  "system_ui",
  "tabled",
+ "telemetry",
  "thiserror 1.0.69",
  "toml 0.8.23",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1803,6 +1805,9 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "telemetry",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5413,10 +5418,12 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 name = "platform_host"
 version = "0.1.0"
 dependencies = [
+ "error-model",
  "futures",
  "js-sys",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7035,6 +7042,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7105,6 +7121,9 @@ dependencies = [
  "leptos_meta",
  "leptos_router",
  "platform_host_web",
+ "telemetry",
+ "tracing",
+ "tracing-wasm",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8517,6 +8536,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "nu-ansi-term",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8892,6 +8961,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vart"

--- a/shared/error-model/src/lib.rs
+++ b/shared/error-model/src/lib.rs
@@ -1,6 +1,78 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCategory {
+    User,
+    Runtime,
+    Host,
+    Validation,
+    Io,
+    Invariant,
+}
+
+impl ErrorCategory {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Runtime => "runtime",
+            Self::Host => "host",
+            Self::Validation => "validation",
+            Self::Io => "io",
+            Self::Invariant => "invariant",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorVisibility {
+    UserSafe,
+    Internal,
+}
+
+impl ErrorVisibility {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UserSafe => "user_safe",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorMetadata {
+    pub category: ErrorCategory,
+    pub visibility: ErrorVisibility,
+    pub code: String,
+    pub operation: Option<String>,
+}
+
+impl ErrorMetadata {
+    #[must_use]
+    pub fn new(
+        category: ErrorCategory,
+        visibility: ErrorVisibility,
+        code: impl Into<String>,
+    ) -> Self {
+        Self {
+            category,
+            visibility,
+            code: code.into(),
+            operation: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_operation(mut self, operation: impl Into<String>) -> Self {
+        self.operation = Some(operation.into());
+        self
+    }
+}
+
 #[derive(Debug, Error, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum InstitutionalError {
     #[error("approval missing for action `{action}`")]

--- a/shared/telemetry/src/lib.rs
+++ b/shared/telemetry/src/lib.rs
@@ -30,3 +30,61 @@ impl Default for TraceContext {
         Self::new()
     }
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeTarget {
+    Desktop,
+    Wasm,
+}
+
+impl RuntimeTarget {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Desktop => "desktop",
+            Self::Wasm => "wasm",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvironmentProfile {
+    Development,
+    Production,
+}
+
+impl EnvironmentProfile {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Development => "development",
+            Self::Production => "production",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UiLogEvent {
+    pub timestamp: String,
+    pub level: String,
+    pub target: String,
+    pub event: String,
+    pub operation: String,
+    pub component: String,
+    pub runtime_target: RuntimeTarget,
+    pub environment: EnvironmentProfile,
+    pub trace: Option<TraceContext>,
+    pub session_id: Option<String>,
+    pub window_id: Option<String>,
+    pub app_id: Option<String>,
+    pub action: Option<String>,
+    pub effect: Option<String>,
+    pub host_strategy: Option<String>,
+    pub capability: Option<String>,
+    pub schema_version: Option<u32>,
+    pub error_category: Option<String>,
+    pub error_code: Option<String>,
+    pub error_visibility: Option<String>,
+}

--- a/ui/README.md
+++ b/ui/README.md
@@ -50,6 +50,35 @@ The shell supports two runtime targets with a shared Rust composition core:
 
 `desktop_runtime` is the common execution core for both targets. It keeps reducer-owned state, effect generation, compositor behavior, and shell composition in one Rust runtime while host capabilities vary by adapter selection.
 
+## Observability and Errors
+`ui/` now standardizes on typed host/runtime errors plus structured tracing-based diagnostics.
+
+- `shared/error-model` provides shared error classification metadata such as category and visibility.
+- `shared/telemetry` provides stable runtime-target and environment-profile types used by UI logs.
+- `platform_host` owns the canonical UI host error contract through `HostError` and `HostResult<T>`.
+- `desktop_runtime` owns shared runtime logging metadata helpers and emits structured events through `tracing`.
+- `site` initializes wasm logging, while `desktop_tauri` initializes the native JSON subscriber.
+
+Required log fields:
+- `timestamp`
+- `level`
+- `target`
+- `event`
+- `operation`
+- `component`
+- `runtime_target`
+- `environment`
+
+Optional fields should be additive and stable, for example `window_id`, `app_id`, `host_strategy`, `error_category`, and `error_code`.
+
+Development builds may emit richer diagnostics. Production defaults should stay concise, favor `warn` and `error` in wasm/browser flows, and avoid leaking internal details to end users.
+
+Prohibited patterns:
+- `Result<_, String>` on public UI host boundaries when a typed `HostError` is appropriate
+- ad hoc free-form runtime diagnostics when structured `tracing` events can be emitted instead
+- logging secrets, raw credentials, uncontrolled payload dumps, or sensitive absolute paths
+- non-test `unwrap`/`expect` on recoverable runtime and host paths
+
 ## Development Workflow
 Use the browser/WASM preview for fast shell iteration and parity checks. Use the Tauri path to validate desktop-only integrations and packaged behavior. Keep all new UI integration behind typed contracts and place presentation-specific models only in `ui/`.
 

--- a/ui/crates/desktop_app_contract/src/lib.rs
+++ b/ui/crates/desktop_app_contract/src/lib.rs
@@ -22,8 +22,8 @@ use platform_host::{
     load_app_state_with_migration, load_pref_with, save_app_state_with, save_pref_with,
     AppStateEnvelope, AppStateStore, CapabilityStatus, ContentCache, ExplorerBackendStatus,
     ExplorerFileReadResult, ExplorerFsService, ExplorerListResult, ExplorerMetadata,
-    ExplorerPermissionMode, ExplorerPermissionState, HostCapabilities, PrefsStore, WallpaperConfig,
-    WallpaperImportRequest, WallpaperLibrarySnapshot,
+    ExplorerPermissionMode, ExplorerPermissionState, HostCapabilities, HostResult, PrefsStore,
+    WallpaperConfig, WallpaperImportRequest, WallpaperLibrarySnapshot,
 };
 use sdk_rs::UiDashboardSnapshotV1;
 use serde::{Deserialize, Serialize};
@@ -555,7 +555,7 @@ impl ConfigService {
         &self,
         namespace: &str,
         key: &str,
-    ) -> Result<Option<T>, String> {
+    ) -> HostResult<Option<T>> {
         load_pref_with(self.prefs.as_ref(), &Self::pref_key(namespace, key)).await
     }
 
@@ -589,10 +589,10 @@ impl AppStateHostService {
         namespace: &str,
         current_schema_version: u32,
         migrate_legacy: F,
-    ) -> Result<Option<T>, String>
+    ) -> HostResult<Option<T>>
     where
         T: serde::de::DeserializeOwned,
-        F: Fn(u32, &AppStateEnvelope) -> Result<Option<T>, String>,
+        F: Fn(u32, &AppStateEnvelope) -> HostResult<Option<T>>,
     {
         load_app_state_with_migration(
             self.store.as_ref(),
@@ -609,7 +609,7 @@ impl AppStateHostService {
         namespace: &str,
         schema_version: u32,
         payload: &T,
-    ) -> Result<(), String> {
+    ) -> HostResult<()> {
         save_app_state_with(self.store.as_ref(), namespace, schema_version, payload).await
     }
 }
@@ -627,20 +627,17 @@ impl PrefsHostService {
     }
 
     /// Loads a typed preference value.
-    pub async fn load<T: serde::de::DeserializeOwned>(
-        &self,
-        key: &str,
-    ) -> Result<Option<T>, String> {
+    pub async fn load<T: serde::de::DeserializeOwned>(&self, key: &str) -> HostResult<Option<T>> {
         load_pref_with(self.store.as_ref(), key).await
     }
 
     /// Saves a typed preference value.
-    pub async fn save<T: Serialize>(&self, key: &str, value: &T) -> Result<(), String> {
+    pub async fn save<T: Serialize>(&self, key: &str, value: &T) -> HostResult<()> {
         save_pref_with(self.store.as_ref(), key, value).await
     }
 
     /// Deletes a stored preference key.
-    pub async fn delete(&self, key: &str) -> Result<(), String> {
+    pub async fn delete(&self, key: &str) -> HostResult<()> {
         self.store.delete_pref(key).await
     }
 }
@@ -658,12 +655,12 @@ impl ExplorerHostService {
     }
 
     /// Returns active backend status.
-    pub async fn status(&self) -> Result<ExplorerBackendStatus, String> {
+    pub async fn status(&self) -> HostResult<ExplorerBackendStatus> {
         self.service.status().await
     }
 
     /// Opens the native-directory picker.
-    pub async fn pick_native_directory(&self) -> Result<ExplorerBackendStatus, String> {
+    pub async fn pick_native_directory(&self) -> HostResult<ExplorerBackendStatus> {
         self.service.pick_native_directory().await
     }
 
@@ -671,46 +668,42 @@ impl ExplorerHostService {
     pub async fn request_permission(
         &self,
         mode: ExplorerPermissionMode,
-    ) -> Result<ExplorerPermissionState, String> {
+    ) -> HostResult<ExplorerPermissionState> {
         self.service.request_permission(mode).await
     }
 
     /// Lists a directory.
-    pub async fn list_dir(&self, path: &str) -> Result<ExplorerListResult, String> {
+    pub async fn list_dir(&self, path: &str) -> HostResult<ExplorerListResult> {
         self.service.list_dir(path).await
     }
 
     /// Reads a text file.
-    pub async fn read_text_file(&self, path: &str) -> Result<ExplorerFileReadResult, String> {
+    pub async fn read_text_file(&self, path: &str) -> HostResult<ExplorerFileReadResult> {
         self.service.read_text_file(path).await
     }
 
     /// Writes a text file.
-    pub async fn write_text_file(
-        &self,
-        path: &str,
-        text: &str,
-    ) -> Result<ExplorerMetadata, String> {
+    pub async fn write_text_file(&self, path: &str, text: &str) -> HostResult<ExplorerMetadata> {
         self.service.write_text_file(path, text).await
     }
 
     /// Creates a directory.
-    pub async fn create_dir(&self, path: &str) -> Result<ExplorerMetadata, String> {
+    pub async fn create_dir(&self, path: &str) -> HostResult<ExplorerMetadata> {
         self.service.create_dir(path).await
     }
 
     /// Creates a text file.
-    pub async fn create_file(&self, path: &str, text: &str) -> Result<ExplorerMetadata, String> {
+    pub async fn create_file(&self, path: &str, text: &str) -> HostResult<ExplorerMetadata> {
         self.service.create_file(path, text).await
     }
 
     /// Deletes a path.
-    pub async fn delete(&self, path: &str, recursive: bool) -> Result<(), String> {
+    pub async fn delete(&self, path: &str, recursive: bool) -> HostResult<()> {
         self.service.delete(path, recursive).await
     }
 
     /// Retrieves metadata for a path.
-    pub async fn stat(&self, path: &str) -> Result<ExplorerMetadata, String> {
+    pub async fn stat(&self, path: &str) -> HostResult<ExplorerMetadata> {
         self.service.stat(path).await
     }
 }
@@ -728,17 +721,17 @@ impl CacheHostService {
     }
 
     /// Stores cached text content.
-    pub async fn put_text(&self, cache_name: &str, key: &str, value: &str) -> Result<(), String> {
+    pub async fn put_text(&self, cache_name: &str, key: &str, value: &str) -> HostResult<()> {
         self.cache.put_text(cache_name, key, value).await
     }
 
     /// Loads cached text content.
-    pub async fn get_text(&self, cache_name: &str, key: &str) -> Result<Option<String>, String> {
+    pub async fn get_text(&self, cache_name: &str, key: &str) -> HostResult<Option<String>> {
         self.cache.get_text(cache_name, key).await
     }
 
     /// Deletes cached text content.
-    pub async fn delete(&self, cache_name: &str, key: &str) -> Result<(), String> {
+    pub async fn delete(&self, cache_name: &str, key: &str) -> HostResult<()> {
         self.cache.delete(cache_name, key).await
     }
 }

--- a/ui/crates/desktop_runtime/Cargo.toml
+++ b/ui/crates/desktop_runtime/Cargo.toml
@@ -34,7 +34,9 @@ system_ui = { path = "../system_ui", default-features = false }
 system_shell = { path = "../system_shell" }
 system_shell_contract = { path = "../system_shell_contract" }
 tabled = { version = "0.20", default-features = false, features = ["ansi"] }
+telemetry = { path = "../../../shared/telemetry" }
 thiserror = "1"
+tracing.workspace = true
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Document", "Element", "HtmlElement", "KeyboardEvent", "MouseEvent", "PointerEvent", "Storage", "Window"] }
 

--- a/ui/crates/desktop_runtime/src/host.rs
+++ b/ui/crates/desktop_runtime/src/host.rs
@@ -13,7 +13,7 @@ mod wallpaper_effects;
 
 use std::rc::Rc;
 
-use leptos::{logging, spawn_local, Callback};
+use leptos::{spawn_local, Callback};
 use platform_host::{
     AppStateStore, ContentCache, ExplorerFsService, ExternalUrlService, HostCapabilities,
     HostServices, NotificationService, PrefsStore, TerminalProcessService, WallpaperAssetService,
@@ -141,7 +141,14 @@ impl DesktopHostContext {
         let host = self.clone();
         spawn_local(async move {
             if let Err(err) = persistence::persist_durable_layout_snapshot(&host, &state).await {
-                logging::warn!("persist durable {cause} snapshot failed: {err}");
+                crate::ui_event!(
+                    warn,
+                    "desktop.persistence.snapshot_failed",
+                    "desktop.persist_durable_snapshot",
+                    "desktop_runtime",
+                    cause = cause,
+                    error = err
+                );
             }
         });
     }

--- a/ui/crates/desktop_runtime/src/host/boot.rs
+++ b/ui/crates/desktop_runtime/src/host/boot.rs
@@ -1,4 +1,4 @@
-use leptos::{create_effect, logging, spawn_local, Callable, Callback};
+use leptos::{create_effect, spawn_local, Callable, Callback};
 
 use crate::{
     current_browser_e2e_config, host::DesktopHostContext, persistence, reducer::DesktopAction,
@@ -54,7 +54,7 @@ pub(super) fn install_boot_hydration(host: DesktopHostContext, dispatch: Callbac
                         persistence::persist_durable_layout_snapshot(&boot_host, &migrated_state)
                             .await
                     {
-                        logging::warn!("migrate legacy snapshot to durable store failed: {err}");
+                        tracing::warn!("migrate legacy snapshot to durable store failed: {err}");
                     }
                 }
             }
@@ -68,7 +68,7 @@ pub(super) fn install_boot_hydration(host: DesktopHostContext, dispatch: Callbac
                 Ok(snapshot) => {
                     dispatch.call(DesktopAction::WallpaperLibraryLoaded { snapshot });
                 }
-                Err(err) => logging::warn!("wallpaper library load failed: {err}"),
+                Err(err) => tracing::warn!("wallpaper library load failed: {err}"),
             }
         });
     });

--- a/ui/crates/desktop_runtime/src/host/host_ui.rs
+++ b/ui/crates/desktop_runtime/src/host/host_ui.rs
@@ -1,6 +1,6 @@
 #[cfg(target_arch = "wasm32")]
 use desktop_app_contract::window_primary_input_dom_id;
-use leptos::{logging, spawn_local};
+use leptos::spawn_local;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{closure::Closure, JsCast};
 
@@ -68,7 +68,7 @@ pub(super) fn open_external_url(host: DesktopHostContext, url: &str) {
     let url = url.to_string();
     spawn_local(async move {
         if let Err(err) = host.external_url_service().open_url(&url).await {
-            logging::warn!("open external url failed for `{url}`: {err}");
+            tracing::warn!("open external url failed for `{url}`: {err}");
         }
     });
 }
@@ -76,7 +76,7 @@ pub(super) fn open_external_url(host: DesktopHostContext, url: &str) {
 pub(super) fn notify(host: DesktopHostContext, title: String, body: String) {
     spawn_local(async move {
         if let Err(err) = host.notification_service().notify(&title, &body).await {
-            logging::warn!("notification dispatch failed: {err}");
+            tracing::warn!("notification dispatch failed: {err}");
         }
     });
 }

--- a/ui/crates/desktop_runtime/src/host/persistence_effects.rs
+++ b/ui/crates/desktop_runtime/src/host/persistence_effects.rs
@@ -1,4 +1,4 @@
-use leptos::{logging, spawn_local, SignalGetUntracked};
+use leptos::{spawn_local, SignalGetUntracked};
 use platform_host::save_pref_with;
 use platform_host_web::{publish_shell_sync_event, ShellSyncEvent};
 
@@ -7,7 +7,7 @@ use crate::{components::DesktopRuntimeContext, host::DesktopHostContext, persist
 pub(super) fn persist_layout(host: DesktopHostContext, runtime: DesktopRuntimeContext) {
     let snapshot_state = runtime.state.get_untracked();
     if let Err(err) = persistence::persist_layout_snapshot(&snapshot_state) {
-        logging::warn!("persist layout failed: {err}");
+        tracing::warn!("persist layout failed: {err}");
     }
     host.persist_durable_snapshot(snapshot_state, "layout");
     publish_shell_sync_event(ShellSyncEvent::LayoutChanged);
@@ -18,7 +18,7 @@ pub(super) fn persist_theme(host: DesktopHostContext, runtime: DesktopRuntimeCon
     let async_host = host.clone();
     spawn_local(async move {
         if let Err(err) = persistence::persist_theme(&async_host, &theme).await {
-            logging::warn!("persist theme failed: {err}");
+            tracing::warn!("persist theme failed: {err}");
         }
     });
     host.persist_durable_snapshot(runtime.state.get_untracked(), "theme");
@@ -29,7 +29,7 @@ pub(super) fn persist_wallpaper(host: DesktopHostContext, runtime: DesktopRuntim
     let wallpaper = runtime.state.get_untracked().wallpaper;
     spawn_local(async move {
         if let Err(err) = persistence::persist_wallpaper(&host, &wallpaper).await {
-            logging::warn!("persist wallpaper failed: {err}");
+            tracing::warn!("persist wallpaper failed: {err}");
         }
     });
     publish_shell_sync_event(ShellSyncEvent::WallpaperChanged);
@@ -40,7 +40,7 @@ pub(super) fn persist_terminal_history(host: DesktopHostContext, runtime: Deskto
     let async_host = host.clone();
     spawn_local(async move {
         if let Err(err) = persistence::persist_terminal_history(&async_host, &history).await {
-            logging::warn!("persist terminal history failed: {err}");
+            tracing::warn!("persist terminal history failed: {err}");
         }
     });
     host.persist_durable_snapshot(runtime.state.get_untracked(), "terminal");
@@ -55,7 +55,7 @@ pub(super) fn save_config(
     let pref_key = format!("{}.{}", namespace, key);
     spawn_local(async move {
         if let Err(err) = save_pref_with(host.prefs_store().as_ref(), &pref_key, &value).await {
-            logging::warn!("persist config preference failed: {err}");
+            tracing::warn!("persist config preference failed: {err}");
         }
     });
 }

--- a/ui/crates/desktop_runtime/src/host/wallpaper_effects.rs
+++ b/ui/crates/desktop_runtime/src/host/wallpaper_effects.rs
@@ -1,4 +1,4 @@
-use leptos::{logging, spawn_local, SignalGetUntracked};
+use leptos::{spawn_local, SignalGetUntracked};
 use platform_host::{
     WallpaperAnimationPolicy, WallpaperConfig, WallpaperDisplayMode, WallpaperImportRequest,
     WallpaperMediaKind, WallpaperPosition, WallpaperSelection,
@@ -14,7 +14,7 @@ pub(super) fn load_library(host: DesktopHostContext, runtime: DesktopRuntimeCont
             Ok(snapshot) => {
                 runtime.dispatch_action(DesktopAction::WallpaperLibraryLoaded { snapshot });
             }
-            Err(err) => logging::warn!("wallpaper library load failed: {err}"),
+            Err(err) => tracing::warn!("wallpaper library load failed: {err}"),
         }
     });
 }
@@ -68,7 +68,7 @@ pub(super) fn import_from_picker(
                 });
                 runtime.dispatch_action(DesktopAction::PreviewWallpaper { config });
             }
-            Err(err) => logging::warn!("wallpaper import failed: {err}"),
+            Err(err) => tracing::warn!("wallpaper import failed: {err}"),
         }
     });
 }
@@ -85,7 +85,7 @@ pub(super) fn update_asset_metadata(
             Ok(asset) => {
                 runtime.dispatch_action(DesktopAction::WallpaperAssetUpdated { asset });
             }
-            Err(err) => logging::warn!("wallpaper metadata update failed: {err}"),
+            Err(err) => tracing::warn!("wallpaper metadata update failed: {err}"),
         }
     });
 }
@@ -101,7 +101,7 @@ pub(super) fn create_collection(
             Ok(collection) => {
                 runtime.dispatch_action(DesktopAction::WallpaperCollectionUpdated { collection });
             }
-            Err(err) => logging::warn!("wallpaper collection create failed: {err}"),
+            Err(err) => tracing::warn!("wallpaper collection create failed: {err}"),
         }
     });
 }
@@ -121,7 +121,7 @@ pub(super) fn rename_collection(
             Ok(collection) => {
                 runtime.dispatch_action(DesktopAction::WallpaperCollectionUpdated { collection });
             }
-            Err(err) => logging::warn!("wallpaper collection rename failed: {err}"),
+            Err(err) => tracing::warn!("wallpaper collection rename failed: {err}"),
         }
     });
 }
@@ -142,7 +142,7 @@ pub(super) fn delete_collection(
                     collection_id: result.collection_id,
                 });
             }
-            Err(err) => logging::warn!("wallpaper collection delete failed: {err}"),
+            Err(err) => tracing::warn!("wallpaper collection delete failed: {err}"),
         }
     });
 }
@@ -184,7 +184,7 @@ pub(super) fn delete_asset(
                     used_bytes: result.used_bytes,
                 });
             }
-            Err(err) => logging::warn!("wallpaper asset delete failed: {err}"),
+            Err(err) => tracing::warn!("wallpaper asset delete failed: {err}"),
         }
     });
 }

--- a/ui/crates/desktop_runtime/src/lib.rs
+++ b/ui/crates/desktop_runtime/src/lib.rs
@@ -53,6 +53,8 @@ pub mod e2e;
 mod effect_executor;
 /// Host-side effect execution and viewport helpers used by the shell runtime.
 pub mod host;
+/// Shared observability helpers and runtime logging metadata.
+pub mod logging;
 /// Core runtime state model and serializable snapshot types.
 pub mod model;
 /// Browser/local persistence helpers for desktop runtime state.

--- a/ui/crates/desktop_runtime/src/logging.rs
+++ b/ui/crates/desktop_runtime/src/logging.rs
@@ -1,0 +1,42 @@
+//! Shared observability helpers for the UI runtime crates.
+
+use telemetry::{EnvironmentProfile, RuntimeTarget};
+
+/// Returns the active runtime target for the compiled binary.
+#[must_use]
+pub const fn runtime_target() -> RuntimeTarget {
+    #[cfg(target_arch = "wasm32")]
+    {
+        RuntimeTarget::Wasm
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        RuntimeTarget::Desktop
+    }
+}
+
+/// Returns the deterministic diagnostics profile for the current build.
+#[must_use]
+pub const fn environment_profile() -> EnvironmentProfile {
+    if cfg!(debug_assertions) {
+        EnvironmentProfile::Development
+    } else {
+        EnvironmentProfile::Production
+    }
+}
+
+/// Emits a schema-stable tracing event with the shared UI runtime fields.
+#[macro_export]
+macro_rules! ui_event {
+    ($level:ident, $event:expr, $operation:expr, $component:expr $(, $name:ident = $value:expr )* $(,)?) => {
+        tracing::$level!(
+            event = %$event,
+            operation = %$operation,
+            component = %$component,
+            runtime_target = %$crate::logging::runtime_target().as_str(),
+            environment = %$crate::logging::environment_profile().as_str(),
+            $($name = %$value,)*
+        );
+    };
+}

--- a/ui/crates/desktop_runtime/src/persistence.rs
+++ b/ui/crates/desktop_runtime/src/persistence.rs
@@ -6,7 +6,8 @@ use crate::model::{DesktopPreferences, DesktopSnapshot, DesktopState, DesktopThe
 use platform_host::build_app_state_envelope;
 use platform_host::{
     load_app_state_with_migration, load_pref_with, migrate_envelope_payload, save_app_state_with,
-    save_pref_with, AppStateEnvelope, WallpaperConfig, WallpaperSelection, DESKTOP_STATE_NAMESPACE,
+    save_pref_with, AppStateEnvelope, HostResult, WallpaperConfig, WallpaperSelection,
+    DESKTOP_STATE_NAMESPACE,
 };
 use serde::{Deserialize, Serialize};
 
@@ -48,7 +49,7 @@ struct LegacyDesktopSnapshotV1 {
 fn migrate_desktop_snapshot(
     schema_version: u32,
     envelope: &AppStateEnvelope,
-) -> Result<Option<DesktopSnapshot>, String> {
+) -> HostResult<Option<DesktopSnapshot>> {
     match schema_version {
         0 => migrate_envelope_payload(envelope).map(Some),
         1 => {
@@ -82,7 +83,7 @@ pub async fn load_boot_snapshot(_host: &DesktopHostContext) -> Option<DesktopSna
             match load_pref_with(host.prefs_store().as_ref(), TERMINAL_HISTORY_KEY).await {
                 Ok(history) => history,
                 Err(err) => {
-                    leptos::logging::warn!("terminal history compatibility load failed: {err}");
+                    tracing::warn!("terminal history compatibility load failed: {err}");
                     None
                 }
             };
@@ -125,7 +126,7 @@ pub async fn load_durable_boot_snapshot(host: &DesktopHostContext) -> Option<Des
     {
         Ok(snapshot) => snapshot,
         Err(err) => {
-            leptos::logging::warn!("durable boot snapshot load failed: {err}");
+            tracing::warn!("durable boot snapshot load failed: {err}");
             None
         }
     }
@@ -147,7 +148,7 @@ pub fn resolve_restore_preferences(
 pub async fn persist_durable_layout_snapshot(
     host: &DesktopHostContext,
     state: &DesktopState,
-) -> Result<(), String> {
+) -> HostResult<()> {
     let snapshot = state.snapshot();
     let store = host.app_state_store();
     save_app_state_with(
@@ -163,7 +164,7 @@ pub async fn persist_durable_layout_snapshot(
 ///
 /// The current implementation keeps full layout persistence in the configured app-state store and
 /// reserves localStorage for lightweight compatibility/prefs state.
-pub fn persist_layout_snapshot(state: &DesktopState) -> Result<(), String> {
+pub fn persist_layout_snapshot(state: &DesktopState) -> HostResult<()> {
     #[cfg(target_arch = "wasm32")]
     {
         // Full desktop layout is durably persisted in IndexedDB via the configured app-state
@@ -181,7 +182,7 @@ pub fn persist_layout_snapshot(state: &DesktopState) -> Result<(), String> {
 }
 
 /// Persists the desktop theme through typed host prefs storage.
-pub async fn persist_theme(host: &DesktopHostContext, theme: &DesktopTheme) -> Result<(), String> {
+pub async fn persist_theme(host: &DesktopHostContext, theme: &DesktopTheme) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), THEME_KEY, theme).await
 }
 
@@ -194,7 +195,7 @@ pub async fn load_theme(host: &DesktopHostContext) -> Option<DesktopTheme> {
             reduced_motion: legacy.reduced_motion,
         }),
         Err(err) => {
-            leptos::logging::warn!("desktop theme load failed: {err}");
+            tracing::warn!("desktop theme load failed: {err}");
             None
         }
     }
@@ -204,7 +205,7 @@ pub async fn load_theme(host: &DesktopHostContext) -> Option<DesktopTheme> {
 pub async fn persist_wallpaper(
     host: &DesktopHostContext,
     wallpaper: &WallpaperConfig,
-) -> Result<(), String> {
+) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), WALLPAPER_KEY, wallpaper).await
 }
 
@@ -219,7 +220,7 @@ pub async fn load_wallpaper(host: &DesktopHostContext) -> Option<WallpaperConfig
             ..WallpaperConfig::default()
         }),
         Err(err) => {
-            leptos::logging::warn!("desktop wallpaper load failed: {err}");
+            tracing::warn!("desktop wallpaper load failed: {err}");
             None
         }
     }
@@ -244,7 +245,7 @@ async fn load_legacy_theme(host: &DesktopHostContext) -> Option<LegacyThemePaylo
     match load_pref_with(host.prefs_store().as_ref(), LEGACY_THEME_KEY).await {
         Ok(value) => value,
         Err(err) => {
-            leptos::logging::warn!("legacy theme compatibility load failed: {err}");
+            tracing::warn!("legacy theme compatibility load failed: {err}");
             None
         }
     }
@@ -254,7 +255,7 @@ async fn load_legacy_theme(host: &DesktopHostContext) -> Option<LegacyThemePaylo
 pub async fn persist_terminal_history(
     host: &DesktopHostContext,
     history: &[String],
-) -> Result<(), String> {
+) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), TERMINAL_HISTORY_KEY, &history).await
 }
 
@@ -263,7 +264,7 @@ pub async fn load_app_policy_overlay(host: &DesktopHostContext) -> Option<AppPol
     match load_pref_with(host.prefs_store().as_ref(), APP_POLICY_KEY).await {
         Ok(value) => value,
         Err(err) => {
-            leptos::logging::warn!("app policy overlay load failed: {err}");
+            tracing::warn!("app policy overlay load failed: {err}");
             None
         }
     }
@@ -273,7 +274,7 @@ pub async fn load_app_policy_overlay(host: &DesktopHostContext) -> Option<AppPol
 pub async fn persist_app_policy_overlay(
     host: &DesktopHostContext,
     policy: &AppPolicyOverlay,
-) -> Result<(), String> {
+) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), APP_POLICY_KEY, policy).await
 }
 

--- a/ui/crates/desktop_runtime/src/runtime_context.rs
+++ b/ui/crates/desktop_runtime/src/runtime_context.rs
@@ -107,7 +107,13 @@ pub fn DesktopProvider(
                     });
                     effects.set(queue);
                 }
-                logging::warn!("desktop reducer error: {err}");
+                crate::ui_event!(
+                    warn,
+                    "desktop.reducer.error",
+                    "desktop.dispatch",
+                    "desktop_runtime",
+                    error = err
+                );
             }
         }
     });

--- a/ui/crates/desktop_tauri/Cargo.toml
+++ b/ui/crates/desktop_tauri/Cargo.toml
@@ -18,3 +18,6 @@ serde_json = "1"
 tauri = { version = "2", default-features = false, features = ["common-controls-v6", "compression", "dynamic-acl", "wry", "x11"] }
 tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
+telemetry = { path = "../../../shared/telemetry" }
+tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/ui/crates/desktop_tauri/src/lib.rs
+++ b/ui/crates/desktop_tauri/src/lib.rs
@@ -18,11 +18,39 @@ mod external_url;
 mod notifications;
 mod prefs;
 
+use std::sync::Once;
+
+fn init_tracing() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_target(true)
+            .with_current_span(false)
+            .with_span_list(false)
+            .finish();
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}
+
 /// Starts the Tauri desktop host process.
 ///
 /// This registers the current host-domain commands and then transfers control to Tauri's runtime
 /// event loop.
 pub fn run() {
+    init_tracing();
+    tracing::info!(
+        event = "desktop_tauri.start",
+        operation = "desktop_tauri.run",
+        component = "desktop_tauri",
+        runtime_target = %telemetry::RuntimeTarget::Desktop.as_str(),
+        environment = %if cfg!(debug_assertions) {
+            telemetry::EnvironmentProfile::Development.as_str()
+        } else {
+            telemetry::EnvironmentProfile::Production.as_str()
+        }
+    );
+
     tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
@@ -51,5 +79,19 @@ pub fn run() {
             prefs::prefs_delete
         ])
         .run(tauri::generate_context!())
-        .expect("desktop_tauri failed to run Tauri application");
+        .unwrap_or_else(|err| {
+            tracing::error!(
+                event = "desktop_tauri.run_failed",
+                operation = "desktop_tauri.run",
+                component = "desktop_tauri",
+                runtime_target = %telemetry::RuntimeTarget::Desktop.as_str(),
+                environment = %if cfg!(debug_assertions) {
+                    telemetry::EnvironmentProfile::Development.as_str()
+                } else {
+                    telemetry::EnvironmentProfile::Production.as_str()
+                },
+                error = %err
+            );
+            std::process::exit(1);
+        });
 }

--- a/ui/crates/platform_host/Cargo.toml
+++ b/ui/crates/platform_host/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+error-model = { path = "../../../shared/error-model" }
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror.workspace = true
 
 [dev-dependencies]
 futures = "0.3"

--- a/ui/crates/platform_host/src/cache/content_cache.rs
+++ b/ui/crates/platform_host/src/cache/content_cache.rs
@@ -4,6 +4,8 @@ use std::{cell::RefCell, collections::HashMap, future::Future, pin::Pin, rc::Rc}
 
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::{CacheErrorKind, HostError, HostResult};
+
 /// Object-safe boxed future used by [`ContentCache`] async methods.
 pub type ContentCacheFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
@@ -15,21 +17,21 @@ pub trait ContentCache {
         cache_name: &'a str,
         key: &'a str,
         value: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>>;
+    ) -> ContentCacheFuture<'a, HostResult<()>>;
 
     /// Reads text content by `cache_name` and `key`.
     fn get_text<'a>(
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<Option<String>, String>>;
+    ) -> ContentCacheFuture<'a, HostResult<Option<String>>>;
 
     /// Deletes cached content by `cache_name` and `key`.
     fn delete<'a>(
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>>;
+    ) -> ContentCacheFuture<'a, HostResult<()>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -42,7 +44,7 @@ impl ContentCache for NoopContentCache {
         _cache_name: &'a str,
         _key: &'a str,
         _value: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 
@@ -50,7 +52,7 @@ impl ContentCache for NoopContentCache {
         &'a self,
         _cache_name: &'a str,
         _key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<Option<String>, String>> {
+    ) -> ContentCacheFuture<'a, HostResult<Option<String>>> {
         Box::pin(async { Ok(None) })
     }
 
@@ -58,7 +60,7 @@ impl ContentCache for NoopContentCache {
         &'a self,
         _cache_name: &'a str,
         _key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 }
@@ -75,7 +77,7 @@ impl ContentCache for MemoryContentCache {
         cache_name: &'a str,
         key: &'a str,
         value: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async move {
             self.inner
                 .borrow_mut()
@@ -88,7 +90,7 @@ impl ContentCache for MemoryContentCache {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<Option<String>, String>> {
+    ) -> ContentCacheFuture<'a, HostResult<Option<String>>> {
         Box::pin(async move {
             Ok(self
                 .inner
@@ -102,7 +104,7 @@ impl ContentCache for MemoryContentCache {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async move {
             self.inner
                 .borrow_mut()
@@ -122,8 +124,15 @@ pub async fn cache_put_json_with<C: ContentCache + ?Sized, T: Serialize>(
     cache_name: &str,
     key: &str,
     value: &T,
-) -> Result<(), String> {
-    let raw = serde_json::to_string(value).map_err(|e| e.to_string())?;
+) -> HostResult<()> {
+    let raw = serde_json::to_string(value).map_err(|err| {
+        HostError::cache(
+            CacheErrorKind::Serialize,
+            "Cached value could not be written",
+        )
+        .with_operation("cache.put")
+        .with_internal(err.to_string())
+    })?;
     cache.put_text(cache_name, key, &raw).await
 }
 
@@ -136,11 +145,18 @@ pub async fn cache_get_json_with<C: ContentCache + ?Sized, T: DeserializeOwned>(
     cache: &C,
     cache_name: &str,
     key: &str,
-) -> Result<Option<T>, String> {
+) -> HostResult<Option<T>> {
     let Some(raw) = cache.get_text(cache_name, key).await? else {
         return Ok(None);
     };
-    let value = serde_json::from_str(&raw).map_err(|e| e.to_string())?;
+    let value = serde_json::from_str(&raw).map_err(|err| {
+        HostError::cache(
+            CacheErrorKind::Deserialize,
+            "Cached value could not be read",
+        )
+        .with_operation("cache.get")
+        .with_internal(err.to_string())
+    })?;
     Ok(Some(value))
 }
 

--- a/ui/crates/platform_host/src/error.rs
+++ b/ui/crates/platform_host/src/error.rs
@@ -1,0 +1,300 @@
+//! Typed error contracts shared by UI host-facing services.
+
+use error_model::{ErrorCategory, ErrorMetadata, ErrorVisibility};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "detail", rename_all = "snake_case")]
+/// Stable error families exposed by UI host-facing contracts.
+pub enum HostErrorKind {
+    /// Persistent app state, preference, or storage-backed failures.
+    Storage(StorageErrorKind),
+    /// Filesystem capability failures surfaced through the host adapter.
+    Fs(FsErrorKind),
+    /// Content cache operation failures.
+    Cache(CacheErrorKind),
+    /// Notification capability failures.
+    Notification(NotificationErrorKind),
+    /// External URL launch failures.
+    ExternalUrl(ExternalUrlErrorKind),
+    /// Wallpaper asset and collection failures.
+    Wallpaper(WallpaperErrorKind),
+    /// Terminal process lifecycle failures.
+    TerminalProcess(TerminalProcessErrorKind),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Storage operation classes for persisted UI data.
+pub enum StorageErrorKind {
+    /// Failed to load previously persisted data.
+    Load,
+    /// Failed to save data.
+    Save,
+    /// Failed to remove persisted data.
+    Delete,
+    /// Failed to enumerate persisted records.
+    List,
+    /// Failed to serialize a value before persistence or transport.
+    Serialize,
+    /// Failed to deserialize a previously persisted value.
+    Deserialize,
+    /// The stored data shape did not match the expected contract.
+    Schema,
+    /// The storage capability is not currently available.
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Filesystem operation classes surfaced to UI code.
+pub enum FsErrorKind {
+    /// Failed to determine service or capability status.
+    Status,
+    /// Access was denied or not granted.
+    Permission,
+    /// Failed to read data.
+    Read,
+    /// Failed to write data.
+    Write,
+    /// Failed to create a resource.
+    Create,
+    /// Failed to delete a resource.
+    Delete,
+    /// Failed to stat or inspect a resource.
+    Stat,
+    /// The requested operation is unsupported on the current target.
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Content cache operation classes.
+pub enum CacheErrorKind {
+    /// Failed to store a cache entry.
+    Put,
+    /// Failed to read a cache entry.
+    Get,
+    /// Failed to remove a cache entry.
+    Delete,
+    /// Failed to serialize a cache payload.
+    Serialize,
+    /// Failed to deserialize a cache payload.
+    Deserialize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Notification delivery failures.
+pub enum NotificationErrorKind {
+    /// Failed to dispatch a notification request.
+    Dispatch,
+    /// Notifications are unsupported on the current target.
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// External URL capability failures.
+pub enum ExternalUrlErrorKind {
+    /// Failed to open the requested URL.
+    Open,
+    /// External URL handling is unsupported on the current target.
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Wallpaper capability failures.
+pub enum WallpaperErrorKind {
+    /// Failed to import a wallpaper asset.
+    Import,
+    /// Failed to list wallpaper assets or collections.
+    List,
+    /// Failed to update wallpaper metadata or associations.
+    Update,
+    /// Failed to create a wallpaper collection.
+    CreateCollection,
+    /// Failed to rename a wallpaper collection.
+    RenameCollection,
+    /// Failed to delete a wallpaper collection.
+    DeleteCollection,
+    /// Failed to delete a wallpaper asset.
+    DeleteAsset,
+    /// Failed to resolve a wallpaper identifier to an asset.
+    Resolve,
+    /// Wallpaper operations are unsupported on the current target.
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Terminal process capability failures.
+pub enum TerminalProcessErrorKind {
+    /// Failed to spawn the process.
+    Spawn,
+    /// Failed to write to the process input.
+    Write,
+    /// Failed to resize the process terminal.
+    Resize,
+    /// Failed to cancel or terminate the process.
+    Cancel,
+    /// Terminal process support is unavailable on the current target.
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+#[error("{safe_message}")]
+/// Typed host capability error shared across UI host-facing contracts.
+pub struct HostError {
+    /// Stable classification metadata used for logs and presentation boundaries.
+    pub metadata: ErrorMetadata,
+    /// High-level host subsystem where the failure originated.
+    pub kind: HostErrorKind,
+    /// Redacted, user-safe message suitable for UI presentation.
+    pub safe_message: String,
+    /// Optional internal-only detail for diagnostics and structured logs.
+    pub internal_message: Option<String>,
+}
+
+/// Typed result alias for UI host-facing contracts.
+pub type HostResult<T> = Result<T, HostError>;
+
+impl HostError {
+    /// Creates a host error with explicit classification metadata.
+    #[must_use]
+    pub fn new(
+        kind: HostErrorKind,
+        category: ErrorCategory,
+        visibility: ErrorVisibility,
+        code: impl Into<String>,
+        safe_message: impl Into<String>,
+    ) -> Self {
+        Self {
+            metadata: ErrorMetadata::new(category, visibility, code),
+            kind,
+            safe_message: safe_message.into(),
+            internal_message: None,
+        }
+    }
+
+    /// Attaches a stable operation identifier to the error metadata.
+    #[must_use]
+    pub fn with_operation(mut self, operation: impl Into<String>) -> Self {
+        self.metadata = self.metadata.with_operation(operation);
+        self
+    }
+
+    /// Attaches internal-only detail for diagnostics.
+    #[must_use]
+    pub fn with_internal(mut self, internal_message: impl Into<String>) -> Self {
+        self.internal_message = Some(internal_message.into());
+        self
+    }
+
+    /// Builds a storage-scoped host error.
+    #[must_use]
+    pub fn storage(kind: StorageErrorKind, safe_message: impl Into<String>) -> Self {
+        Self::new(
+            HostErrorKind::Storage(kind),
+            ErrorCategory::Host,
+            ErrorVisibility::UserSafe,
+            format!("storage.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+
+    /// Builds a validation-scoped storage error.
+    #[must_use]
+    pub fn validation(kind: StorageErrorKind, safe_message: impl Into<String>) -> Self {
+        Self::new(
+            HostErrorKind::Storage(kind),
+            ErrorCategory::Validation,
+            ErrorVisibility::UserSafe,
+            format!("storage.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+
+    /// Builds a filesystem-scoped host error.
+    #[must_use]
+    pub fn fs(kind: FsErrorKind, safe_message: impl Into<String>) -> Self {
+        Self::new(
+            HostErrorKind::Fs(kind),
+            ErrorCategory::Host,
+            ErrorVisibility::UserSafe,
+            format!("fs.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+
+    /// Builds a cache-scoped host error.
+    #[must_use]
+    pub fn cache(kind: CacheErrorKind, safe_message: impl Into<String>) -> Self {
+        Self::new(
+            HostErrorKind::Cache(kind),
+            ErrorCategory::Host,
+            ErrorVisibility::UserSafe,
+            format!("cache.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+
+    /// Builds a notification-scoped host error.
+    #[must_use]
+    pub fn notification(kind: NotificationErrorKind, safe_message: impl Into<String>) -> Self {
+        Self::new(
+            HostErrorKind::Notification(kind),
+            ErrorCategory::Host,
+            ErrorVisibility::UserSafe,
+            format!("notification.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+
+    /// Builds an external-URL-scoped host error.
+    #[must_use]
+    pub fn external_url(kind: ExternalUrlErrorKind, safe_message: impl Into<String>) -> Self {
+        Self::new(
+            HostErrorKind::ExternalUrl(kind),
+            ErrorCategory::Host,
+            ErrorVisibility::UserSafe,
+            format!("external_url.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+
+    /// Builds a wallpaper-scoped host error.
+    #[must_use]
+    pub fn wallpaper(kind: WallpaperErrorKind, safe_message: impl Into<String>) -> Self {
+        Self::new(
+            HostErrorKind::Wallpaper(kind),
+            ErrorCategory::Host,
+            ErrorVisibility::UserSafe,
+            format!("wallpaper.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+
+    /// Builds a terminal-process-scoped host error.
+    #[must_use]
+    pub fn terminal_process(
+        kind: TerminalProcessErrorKind,
+        safe_message: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            HostErrorKind::TerminalProcess(kind),
+            ErrorCategory::Host,
+            ErrorVisibility::UserSafe,
+            format!("terminal_process.{kind:?}").to_lowercase(),
+            safe_message,
+        )
+    }
+}
+
+impl From<HostError> for String {
+    fn from(value: HostError) -> Self {
+        value.safe_message
+    }
+}

--- a/ui/crates/platform_host/src/external_url.rs
+++ b/ui/crates/platform_host/src/external_url.rs
@@ -2,13 +2,15 @@
 
 use std::{future::Future, pin::Pin};
 
+use crate::HostResult;
+
 /// Object-safe boxed future used by [`ExternalUrlService`].
 pub type ExternalUrlFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// Host service for opening external URLs outside the desktop shell.
 pub trait ExternalUrlService {
     /// Opens a URL using the host's external navigation mechanism.
-    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, Result<(), String>>;
+    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, HostResult<()>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -16,7 +18,7 @@ pub trait ExternalUrlService {
 pub struct NoopExternalUrlService;
 
 impl ExternalUrlService for NoopExternalUrlService {
-    fn open_url<'a>(&'a self, _url: &'a str) -> ExternalUrlFuture<'a, Result<(), String>> {
+    fn open_url<'a>(&'a self, _url: &'a str) -> ExternalUrlFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 }

--- a/ui/crates/platform_host/src/fs/service.rs
+++ b/ui/crates/platform_host/src/fs/service.rs
@@ -6,6 +6,7 @@ use super::types::{
     ExplorerBackend, ExplorerBackendStatus, ExplorerFileReadResult, ExplorerListResult,
     ExplorerMetadata, ExplorerPermissionMode, ExplorerPermissionState,
 };
+use crate::{FsErrorKind, HostError, HostResult};
 
 /// Object-safe boxed future used by [`ExplorerFsService`] async methods.
 pub type ExplorerFsFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
@@ -13,60 +14,57 @@ pub type ExplorerFsFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 /// Host service for explorer filesystem operations and backend capability state.
 pub trait ExplorerFsService {
     /// Returns the current explorer backend status and capability information.
-    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>>;
+    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>>;
 
     /// Opens the native-directory picker and returns updated backend status.
     fn pick_native_directory<'a>(
         &'a self,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>>;
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>>;
 
     /// Requests explorer permissions for the active backend.
     fn request_permission<'a>(
         &'a self,
         mode: ExplorerPermissionMode,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerPermissionState, String>>;
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerPermissionState>>;
 
     /// Lists a directory using the active explorer backend.
     fn list_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerListResult, String>>;
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerListResult>>;
 
     /// Reads a text file using the active explorer backend.
     fn read_text_file<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerFileReadResult, String>>;
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerFileReadResult>>;
 
     /// Writes a text file using the active explorer backend.
     fn write_text_file<'a>(
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>>;
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>>;
 
     /// Creates a directory using the active explorer backend.
     fn create_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>>;
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>>;
 
     /// Creates a text file using the active explorer backend.
     fn create_file<'a>(
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>>;
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>>;
 
     /// Deletes a file or directory using the active explorer backend.
-    fn delete<'a>(
-        &'a self,
-        path: &'a str,
-        recursive: bool,
-    ) -> ExplorerFsFuture<'a, Result<(), String>>;
+    fn delete<'a>(&'a self, path: &'a str, recursive: bool)
+        -> ExplorerFsFuture<'a, HostResult<()>>;
 
     /// Retrieves metadata for a path using the active explorer backend.
-    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>>;
+    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -84,40 +82,44 @@ impl NoopExplorerFsService {
         }
     }
 
-    fn unsupported_error(op: &str) -> String {
-        format!("explorer fs unavailable: {op}")
+    fn unsupported_error(op: &str) -> HostError {
+        HostError::fs(
+            FsErrorKind::Unsupported,
+            "Explorer filesystem support is unavailable",
+        )
+        .with_operation(op)
     }
 }
 
 impl ExplorerFsService for NoopExplorerFsService {
-    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         Box::pin(async { Ok(Self::unsupported_status()) })
     }
 
     fn pick_native_directory<'a>(
         &'a self,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         Box::pin(async { Err(Self::unsupported_error("pick_native_directory")) })
     }
 
     fn request_permission<'a>(
         &'a self,
         _mode: ExplorerPermissionMode,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerPermissionState, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerPermissionState>> {
         Box::pin(async { Ok(ExplorerPermissionState::Unsupported) })
     }
 
     fn list_dir<'a>(
         &'a self,
         _path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerListResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerListResult>> {
         Box::pin(async { Err(Self::unsupported_error("list_dir")) })
     }
 
     fn read_text_file<'a>(
         &'a self,
         _path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerFileReadResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerFileReadResult>> {
         Box::pin(async { Err(Self::unsupported_error("read_text_file")) })
     }
 
@@ -125,14 +127,14 @@ impl ExplorerFsService for NoopExplorerFsService {
         &'a self,
         _path: &'a str,
         _text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async { Err(Self::unsupported_error("write_text_file")) })
     }
 
     fn create_dir<'a>(
         &'a self,
         _path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async { Err(Self::unsupported_error("create_dir")) })
     }
 
@@ -140,7 +142,7 @@ impl ExplorerFsService for NoopExplorerFsService {
         &'a self,
         _path: &'a str,
         _text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async { Err(Self::unsupported_error("create_file")) })
     }
 
@@ -148,14 +150,11 @@ impl ExplorerFsService for NoopExplorerFsService {
         &'a self,
         _path: &'a str,
         _recursive: bool,
-    ) -> ExplorerFsFuture<'a, Result<(), String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<()>> {
         Box::pin(async { Err(Self::unsupported_error("delete")) })
     }
 
-    fn stat<'a>(
-        &'a self,
-        _path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    fn stat<'a>(&'a self, _path: &'a str) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async { Err(Self::unsupported_error("stat")) })
     }
 }
@@ -165,6 +164,7 @@ mod tests {
     use futures::executor::block_on;
 
     use super::*;
+    use crate::HostErrorKind;
 
     #[test]
     fn noop_explorer_fs_service_reports_unsupported() {
@@ -180,6 +180,7 @@ mod tests {
             ExplorerPermissionState::Unsupported
         );
         let err = block_on(fs_obj.list_dir("/")).expect_err("list should fail");
-        assert!(err.contains("list_dir"));
+        assert_eq!(err.kind, HostErrorKind::Fs(FsErrorKind::Unsupported));
+        assert_eq!(err.metadata.operation.as_deref(), Some("list_dir"));
     }
 }

--- a/ui/crates/platform_host/src/lib.rs
+++ b/ui/crates/platform_host/src/lib.rs
@@ -12,6 +12,7 @@
 #![warn(missing_docs, rustdoc::broken_intra_doc_links)]
 
 pub mod cache;
+pub mod error;
 pub mod external_url;
 pub mod fs;
 pub mod host;
@@ -25,6 +26,10 @@ pub mod wallpaper;
 pub use cache::{
     cache_get_json_with, cache_put_json_with, ContentCache, ContentCacheFuture, MemoryContentCache,
     NoopContentCache,
+};
+pub use error::{
+    CacheErrorKind, ExternalUrlErrorKind, FsErrorKind, HostError, HostErrorKind, HostResult,
+    NotificationErrorKind, StorageErrorKind, TerminalProcessErrorKind, WallpaperErrorKind,
 };
 pub use external_url::{ExternalUrlFuture, ExternalUrlService, NoopExternalUrlService};
 pub use fs::path::normalize_virtual_path;

--- a/ui/crates/platform_host/src/notifications/service.rs
+++ b/ui/crates/platform_host/src/notifications/service.rs
@@ -2,6 +2,8 @@
 
 use std::{future::Future, pin::Pin};
 
+use crate::HostResult;
+
 /// Object-safe boxed future used by [`NotificationService`].
 pub type NotificationFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
@@ -12,7 +14,7 @@ pub trait NotificationService {
         &'a self,
         title: &'a str,
         body: &'a str,
-    ) -> NotificationFuture<'a, Result<(), String>>;
+    ) -> NotificationFuture<'a, HostResult<()>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -24,7 +26,7 @@ impl NotificationService for NoopNotificationService {
         &'a self,
         _title: &'a str,
         _body: &'a str,
-    ) -> NotificationFuture<'a, Result<(), String>> {
+    ) -> NotificationFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 }

--- a/ui/crates/platform_host/src/session.rs
+++ b/ui/crates/platform_host/src/session.rs
@@ -5,6 +5,8 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 
+use crate::{HostError, HostResult, StorageErrorKind};
+
 #[derive(Debug, Clone)]
 /// In-memory session-scoped key/value JSON store used by non-durable UI state.
 pub struct MemorySessionStore {
@@ -40,8 +42,15 @@ impl MemorySessionStore {
     /// # Errors
     ///
     /// Returns an error when `value` cannot be serialized to JSON.
-    pub fn set<T: Serialize>(&self, key: impl Into<String>, value: &T) -> Result<(), String> {
-        let json = serde_json::to_value(value).map_err(|e| e.to_string())?;
+    pub fn set<T: Serialize>(&self, key: impl Into<String>, value: &T) -> HostResult<()> {
+        let json = serde_json::to_value(value).map_err(|err| {
+            HostError::storage(
+                StorageErrorKind::Serialize,
+                "Session state could not be encoded",
+            )
+            .with_operation("session.set")
+            .with_internal(err.to_string())
+        })?;
         self.set_json(key, json);
         Ok(())
     }

--- a/ui/crates/platform_host/src/storage/app_state.rs
+++ b/ui/crates/platform_host/src/storage/app_state.rs
@@ -5,6 +5,8 @@ use std::{cell::RefCell, collections::HashMap, future::Future, pin::Pin, rc::Rc}
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::{HostError, HostResult, StorageErrorKind};
+
 /// Version for [`AppStateEnvelope`] metadata serialization.
 pub const APP_STATE_ENVELOPE_VERSION: u32 = 1;
 /// Namespace used by the desktop runtime durable snapshot.
@@ -57,24 +59,22 @@ pub trait AppStateStore {
     fn load_app_state_envelope<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<Option<AppStateEnvelope>, String>>;
+    ) -> AppStateStoreFuture<'a, HostResult<Option<AppStateEnvelope>>>;
 
     /// Saves a full app-state envelope.
     fn save_app_state_envelope<'a>(
         &'a self,
         envelope: &'a AppStateEnvelope,
-    ) -> AppStateStoreFuture<'a, Result<(), String>>;
+    ) -> AppStateStoreFuture<'a, HostResult<()>>;
 
     /// Deletes persisted app state for a namespace.
     fn delete_app_state<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<(), String>>;
+    ) -> AppStateStoreFuture<'a, HostResult<()>>;
 
     /// Lists namespaces currently present in the app-state store.
-    fn list_app_state_namespaces<'a>(
-        &'a self,
-    ) -> AppStateStoreFuture<'a, Result<Vec<String>, String>>;
+    fn list_app_state_namespaces<'a>(&'a self) -> AppStateStoreFuture<'a, HostResult<Vec<String>>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -85,27 +85,25 @@ impl AppStateStore for NoopAppStateStore {
     fn load_app_state_envelope<'a>(
         &'a self,
         _namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<Option<AppStateEnvelope>, String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<Option<AppStateEnvelope>>> {
         Box::pin(async { Ok(None) })
     }
 
     fn save_app_state_envelope<'a>(
         &'a self,
         _envelope: &'a AppStateEnvelope,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 
     fn delete_app_state<'a>(
         &'a self,
         _namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 
-    fn list_app_state_namespaces<'a>(
-        &'a self,
-    ) -> AppStateStoreFuture<'a, Result<Vec<String>, String>> {
+    fn list_app_state_namespaces<'a>(&'a self) -> AppStateStoreFuture<'a, HostResult<Vec<String>>> {
         Box::pin(async { Ok(Vec::new()) })
     }
 }
@@ -128,14 +126,14 @@ impl AppStateStore for MemoryAppStateStore {
     fn load_app_state_envelope<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<Option<AppStateEnvelope>, String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<Option<AppStateEnvelope>>> {
         Box::pin(async move { Ok(self.inner.borrow().get(namespace).cloned()) })
     }
 
     fn save_app_state_envelope<'a>(
         &'a self,
         envelope: &'a AppStateEnvelope,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async move {
             self.inner
                 .borrow_mut()
@@ -147,16 +145,14 @@ impl AppStateStore for MemoryAppStateStore {
     fn delete_app_state<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async move {
             self.inner.borrow_mut().remove(namespace);
             Ok(())
         })
     }
 
-    fn list_app_state_namespaces<'a>(
-        &'a self,
-    ) -> AppStateStoreFuture<'a, Result<Vec<String>, String>> {
+    fn list_app_state_namespaces<'a>(&'a self) -> AppStateStoreFuture<'a, HostResult<Vec<String>>> {
         Box::pin(async move {
             let mut keys = self.inner.borrow().keys().cloned().collect::<Vec<_>>();
             keys.sort();
@@ -174,8 +170,15 @@ pub fn build_app_state_envelope<T: Serialize>(
     namespace: &str,
     schema_version: u32,
     payload: &T,
-) -> Result<AppStateEnvelope, String> {
-    let payload = serde_json::to_value(payload).map_err(|e| e.to_string())?;
+) -> HostResult<AppStateEnvelope> {
+    let payload = serde_json::to_value(payload).map_err(|err| {
+        HostError::storage(
+            StorageErrorKind::Serialize,
+            "App state could not be encoded",
+        )
+        .with_operation("app_state.build_envelope")
+        .with_internal(err.to_string())
+    })?;
     Ok(AppStateEnvelope::new(
         namespace.to_string(),
         schema_version,
@@ -188,10 +191,15 @@ pub fn build_app_state_envelope<T: Serialize>(
 /// # Errors
 ///
 /// Returns an error when deserialization fails.
-pub fn migrate_envelope_payload<T: DeserializeOwned>(
-    envelope: &AppStateEnvelope,
-) -> Result<T, String> {
-    serde_json::from_value(envelope.payload.clone()).map_err(|e| e.to_string())
+pub fn migrate_envelope_payload<T: DeserializeOwned>(envelope: &AppStateEnvelope) -> HostResult<T> {
+    serde_json::from_value(envelope.payload.clone()).map_err(|err| {
+        HostError::storage(
+            StorageErrorKind::Deserialize,
+            "App state payload could not be decoded",
+        )
+        .with_operation("app_state.migrate_payload")
+        .with_internal(err.to_string())
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -225,7 +233,7 @@ pub async fn save_app_state_with<S: AppStateStore + ?Sized, T: Serialize>(
     namespace: &str,
     schema_version: u32,
     payload: &T,
-) -> Result<(), String> {
+) -> HostResult<()> {
     let envelope = build_app_state_envelope(namespace, schema_version, payload)?;
     store.save_app_state_envelope(&envelope).await
 }
@@ -244,7 +252,7 @@ pub async fn load_app_state_typed_with<S: AppStateStore + ?Sized, T: Deserialize
     store: &S,
     namespace: &str,
     schema_policy: AppStateSchemaPolicy,
-) -> Result<Option<T>, String> {
+) -> HostResult<Option<T>> {
     let Some(envelope) = store.load_app_state_envelope(namespace).await? else {
         return Ok(None);
     };
@@ -266,11 +274,11 @@ pub async fn load_app_state_with_migration<S, T, F>(
     namespace: &str,
     current_schema_version: u32,
     migrate_legacy: F,
-) -> Result<Option<T>, String>
+) -> HostResult<Option<T>>
 where
     S: AppStateStore + ?Sized,
     T: DeserializeOwned,
-    F: Fn(u32, &AppStateEnvelope) -> Result<Option<T>, String>,
+    F: Fn(u32, &AppStateEnvelope) -> HostResult<Option<T>>,
 {
     let Some(envelope) = store.load_app_state_envelope(namespace).await? else {
         return Ok(None);
@@ -281,7 +289,7 @@ where
 fn decode_typed_app_state_envelope<T: DeserializeOwned>(
     envelope: &AppStateEnvelope,
     schema_policy: AppStateSchemaPolicy,
-) -> Result<Option<T>, String> {
+) -> HostResult<Option<T>> {
     if envelope.envelope_version != APP_STATE_ENVELOPE_VERSION {
         return Ok(None);
     }
@@ -295,10 +303,10 @@ fn decode_typed_app_state_with_migration<T, F>(
     envelope: &AppStateEnvelope,
     current_schema_version: u32,
     migrate_legacy: F,
-) -> Result<Option<T>, String>
+) -> HostResult<Option<T>>
 where
     T: DeserializeOwned,
-    F: Fn(u32, &AppStateEnvelope) -> Result<Option<T>, String>,
+    F: Fn(u32, &AppStateEnvelope) -> HostResult<Option<T>>,
 {
     if envelope.envelope_version != APP_STATE_ENVELOPE_VERSION {
         return Ok(None);
@@ -321,6 +329,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::HostErrorKind;
 
     #[derive(Debug, Deserialize, PartialEq)]
     struct TestPayload {
@@ -380,7 +389,15 @@ mod tests {
     fn build_app_state_envelope_returns_error_for_unserializable_payload() {
         let err = build_app_state_envelope("app.example", 1, &NonSerializable)
             .expect_err("expected serialization error");
-        assert!(err.contains("boom"));
+        assert_eq!(
+            err.kind,
+            HostErrorKind::Storage(StorageErrorKind::Serialize)
+        );
+        assert_eq!(
+            err.metadata.operation.as_deref(),
+            Some("app_state.build_envelope")
+        );
+        assert_eq!(err.internal_message.as_deref(), Some("boom"));
     }
 
     #[test]
@@ -415,7 +432,15 @@ mod tests {
 
         let err = migrate_envelope_payload::<TestPayload>(&envelope)
             .expect_err("expected decode failure");
-        assert!(!err.is_empty());
+        assert_eq!(
+            err.kind,
+            HostErrorKind::Storage(StorageErrorKind::Deserialize)
+        );
+        assert_eq!(
+            err.metadata.operation.as_deref(),
+            Some("app_state.migrate_payload")
+        );
+        assert!(!err.safe_message.is_empty());
     }
 
     #[test]

--- a/ui/crates/platform_host/src/storage/prefs.rs
+++ b/ui/crates/platform_host/src/storage/prefs.rs
@@ -4,26 +4,25 @@ use std::{cell::RefCell, collections::HashMap, future::Future, pin::Pin, rc::Rc}
 
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::{HostError, HostResult, StorageErrorKind};
+
 /// Object-safe boxed future used by [`PrefsStore`] async methods.
 pub type PrefsStoreFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// Host service for lightweight preference values (JSON stored as text per key).
 pub trait PrefsStore {
     /// Loads a raw JSON string for a preference key.
-    fn load_pref<'a>(
-        &'a self,
-        key: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<Option<String>, String>>;
+    fn load_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<Option<String>>>;
 
     /// Saves a raw JSON string for a preference key.
     fn save_pref<'a>(
         &'a self,
         key: &'a str,
         raw_json: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<(), String>>;
+    ) -> PrefsStoreFuture<'a, HostResult<()>>;
 
     /// Deletes a preference key.
-    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, Result<(), String>>;
+    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<()>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -31,10 +30,7 @@ pub trait PrefsStore {
 pub struct NoopPrefsStore;
 
 impl PrefsStore for NoopPrefsStore {
-    fn load_pref<'a>(
-        &'a self,
-        _key: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<Option<String>, String>> {
+    fn load_pref<'a>(&'a self, _key: &'a str) -> PrefsStoreFuture<'a, HostResult<Option<String>>> {
         Box::pin(async { Ok(None) })
     }
 
@@ -42,11 +38,11 @@ impl PrefsStore for NoopPrefsStore {
         &'a self,
         _key: &'a str,
         _raw_json: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<(), String>> {
+    ) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 
-    fn delete_pref<'a>(&'a self, _key: &'a str) -> PrefsStoreFuture<'a, Result<(), String>> {
+    fn delete_pref<'a>(&'a self, _key: &'a str) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async { Ok(()) })
     }
 }
@@ -58,10 +54,7 @@ pub struct MemoryPrefsStore {
 }
 
 impl PrefsStore for MemoryPrefsStore {
-    fn load_pref<'a>(
-        &'a self,
-        key: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<Option<String>, String>> {
+    fn load_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<Option<String>>> {
         Box::pin(async move { Ok(self.inner.borrow().get(key).cloned()) })
     }
 
@@ -69,7 +62,7 @@ impl PrefsStore for MemoryPrefsStore {
         &'a self,
         key: &'a str,
         raw_json: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<(), String>> {
+    ) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async move {
             self.inner
                 .borrow_mut()
@@ -78,7 +71,7 @@ impl PrefsStore for MemoryPrefsStore {
         })
     }
 
-    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, Result<(), String>> {
+    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async move {
             self.inner.borrow_mut().remove(key);
             Ok(())
@@ -94,11 +87,18 @@ impl PrefsStore for MemoryPrefsStore {
 pub async fn load_pref_with<S: PrefsStore + ?Sized, T: DeserializeOwned>(
     store: &S,
     key: &str,
-) -> Result<Option<T>, String> {
+) -> HostResult<Option<T>> {
     let Some(raw) = store.load_pref(key).await? else {
         return Ok(None);
     };
-    let value = serde_json::from_str(&raw).map_err(|e| e.to_string())?;
+    let value = serde_json::from_str(&raw).map_err(|err| {
+        HostError::storage(
+            StorageErrorKind::Deserialize,
+            "Stored preference could not be read",
+        )
+        .with_operation("prefs.load")
+        .with_internal(err.to_string())
+    })?;
     Ok(Some(value))
 }
 
@@ -111,8 +111,15 @@ pub async fn save_pref_with<S: PrefsStore + ?Sized, T: Serialize>(
     store: &S,
     key: &str,
     value: &T,
-) -> Result<(), String> {
-    let raw = serde_json::to_string(value).map_err(|e| e.to_string())?;
+) -> HostResult<()> {
+    let raw = serde_json::to_string(value).map_err(|err| {
+        HostError::storage(
+            StorageErrorKind::Serialize,
+            "Preference value could not be written",
+        )
+        .with_operation("prefs.save")
+        .with_internal(err.to_string())
+    })?;
     store.save_pref(key, &raw).await
 }
 

--- a/ui/crates/platform_host/src/terminal_process.rs
+++ b/ui/crates/platform_host/src/terminal_process.rs
@@ -2,6 +2,8 @@
 
 use std::{future::Future, pin::Pin};
 
+use crate::{HostError, HostResult, TerminalProcessErrorKind};
+
 /// Stable identifier for one host terminal-process session.
 pub type TerminalSessionId = u64;
 
@@ -49,25 +51,25 @@ pub trait TerminalProcessService {
     fn spawn<'a>(
         &'a self,
         cwd: &'a str,
-    ) -> TerminalProcessFuture<'a, Result<TerminalSessionId, String>>;
+    ) -> TerminalProcessFuture<'a, HostResult<TerminalSessionId>>;
 
     /// Writes text into a running terminal-process session.
     fn write<'a>(
         &'a self,
         request: TerminalWriteRequest,
-    ) -> TerminalProcessFuture<'a, Result<(), String>>;
+    ) -> TerminalProcessFuture<'a, HostResult<()>>;
 
     /// Resizes a running terminal-process session.
     fn resize<'a>(
         &'a self,
         request: TerminalResizeRequest,
-    ) -> TerminalProcessFuture<'a, Result<(), String>>;
+    ) -> TerminalProcessFuture<'a, HostResult<()>>;
 
     /// Cancels a running terminal-process session.
     fn cancel<'a>(
         &'a self,
         session_id: TerminalSessionId,
-    ) -> TerminalProcessFuture<'a, Result<(), String>>;
+    ) -> TerminalProcessFuture<'a, HostResult<()>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -78,28 +80,52 @@ impl TerminalProcessService for NoopTerminalProcessService {
     fn spawn<'a>(
         &'a self,
         _cwd: &'a str,
-    ) -> TerminalProcessFuture<'a, Result<TerminalSessionId, String>> {
-        Box::pin(async { Err("terminal process unavailable: spawn".to_string()) })
+    ) -> TerminalProcessFuture<'a, HostResult<TerminalSessionId>> {
+        Box::pin(async {
+            Err(HostError::terminal_process(
+                TerminalProcessErrorKind::Unsupported,
+                "Terminal process support is unavailable",
+            )
+            .with_operation("terminal.spawn"))
+        })
     }
 
     fn write<'a>(
         &'a self,
         _request: TerminalWriteRequest,
-    ) -> TerminalProcessFuture<'a, Result<(), String>> {
-        Box::pin(async { Err("terminal process unavailable: write".to_string()) })
+    ) -> TerminalProcessFuture<'a, HostResult<()>> {
+        Box::pin(async {
+            Err(HostError::terminal_process(
+                TerminalProcessErrorKind::Unsupported,
+                "Terminal process support is unavailable",
+            )
+            .with_operation("terminal.write"))
+        })
     }
 
     fn resize<'a>(
         &'a self,
         _request: TerminalResizeRequest,
-    ) -> TerminalProcessFuture<'a, Result<(), String>> {
-        Box::pin(async { Err("terminal process unavailable: resize".to_string()) })
+    ) -> TerminalProcessFuture<'a, HostResult<()>> {
+        Box::pin(async {
+            Err(HostError::terminal_process(
+                TerminalProcessErrorKind::Unsupported,
+                "Terminal process support is unavailable",
+            )
+            .with_operation("terminal.resize"))
+        })
     }
 
     fn cancel<'a>(
         &'a self,
         _session_id: TerminalSessionId,
-    ) -> TerminalProcessFuture<'a, Result<(), String>> {
-        Box::pin(async { Err("terminal process unavailable: cancel".to_string()) })
+    ) -> TerminalProcessFuture<'a, HostResult<()>> {
+        Box::pin(async {
+            Err(HostError::terminal_process(
+                TerminalProcessErrorKind::Unsupported,
+                "Terminal process support is unavailable",
+            )
+            .with_operation("terminal.cancel"))
+        })
     }
 }

--- a/ui/crates/platform_host/src/wallpaper.rs
+++ b/ui/crates/platform_host/src/wallpaper.rs
@@ -4,6 +4,8 @@ use std::{future::Future, pin::Pin};
 
 use serde::{Deserialize, Serialize};
 
+use crate::{HostError, HostResult, WallpaperErrorKind};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 /// Identifies either a built-in wallpaper or an imported managed asset.
@@ -273,50 +275,49 @@ pub trait WallpaperAssetService {
     fn import_from_picker<'a>(
         &'a self,
         request: WallpaperImportRequest,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperImportResult, String>>;
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperImportResult>>;
 
     /// Lists the current wallpaper library snapshot.
-    fn list_library<'a>(
-        &'a self,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperLibrarySnapshot, String>>;
+    fn list_library<'a>(&'a self)
+        -> WallpaperAssetFuture<'a, HostResult<WallpaperLibrarySnapshot>>;
 
     /// Updates asset metadata by patch.
     fn update_asset_metadata<'a>(
         &'a self,
         asset_id: &'a str,
         patch: WallpaperAssetMetadataPatch,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetRecord, String>>;
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetRecord>>;
 
     /// Creates a wallpaper collection.
     fn create_collection<'a>(
         &'a self,
         display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>>;
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>>;
 
     /// Renames a wallpaper collection.
     fn rename_collection<'a>(
         &'a self,
         collection_id: &'a str,
         display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>>;
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>>;
 
     /// Deletes a wallpaper collection and removes its memberships.
     fn delete_collection<'a>(
         &'a self,
         collection_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollectionDeleteResult, String>>;
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollectionDeleteResult>>;
 
     /// Deletes a wallpaper asset.
     fn delete_asset<'a>(
         &'a self,
         asset_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetDeleteResult, String>>;
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetDeleteResult>>;
 
     /// Resolves a wallpaper selection to a renderer-safe source.
     fn resolve_source<'a>(
         &'a self,
         selection: WallpaperSelection,
-    ) -> WallpaperAssetFuture<'a, Result<Option<ResolvedWallpaperSource>, String>>;
+    ) -> WallpaperAssetFuture<'a, HostResult<Option<ResolvedWallpaperSource>>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -324,8 +325,12 @@ pub trait WallpaperAssetService {
 pub struct NoopWallpaperAssetService;
 
 impl NoopWallpaperAssetService {
-    fn unsupported(op: &str) -> String {
-        format!("wallpaper asset service unavailable: {op}")
+    fn unsupported(op: &str) -> HostError {
+        HostError::wallpaper(
+            WallpaperErrorKind::Unsupported,
+            "Wallpaper library support is unavailable",
+        )
+        .with_operation(op)
     }
 }
 
@@ -333,13 +338,13 @@ impl WallpaperAssetService for NoopWallpaperAssetService {
     fn import_from_picker<'a>(
         &'a self,
         _request: WallpaperImportRequest,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperImportResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperImportResult>> {
         Box::pin(async { Err(Self::unsupported("import_from_picker")) })
     }
 
     fn list_library<'a>(
         &'a self,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperLibrarySnapshot, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperLibrarySnapshot>> {
         Box::pin(async { Ok(WallpaperLibrarySnapshot::default()) })
     }
 
@@ -347,14 +352,14 @@ impl WallpaperAssetService for NoopWallpaperAssetService {
         &'a self,
         _asset_id: &'a str,
         _patch: WallpaperAssetMetadataPatch,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetRecord, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetRecord>> {
         Box::pin(async { Err(Self::unsupported("update_asset_metadata")) })
     }
 
     fn create_collection<'a>(
         &'a self,
         _display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>> {
         Box::pin(async { Err(Self::unsupported("create_collection")) })
     }
 
@@ -362,28 +367,28 @@ impl WallpaperAssetService for NoopWallpaperAssetService {
         &'a self,
         _collection_id: &'a str,
         _display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>> {
         Box::pin(async { Err(Self::unsupported("rename_collection")) })
     }
 
     fn delete_collection<'a>(
         &'a self,
         _collection_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollectionDeleteResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollectionDeleteResult>> {
         Box::pin(async { Err(Self::unsupported("delete_collection")) })
     }
 
     fn delete_asset<'a>(
         &'a self,
         _asset_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetDeleteResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetDeleteResult>> {
         Box::pin(async { Err(Self::unsupported("delete_asset")) })
     }
 
     fn resolve_source<'a>(
         &'a self,
         _selection: WallpaperSelection,
-    ) -> WallpaperAssetFuture<'a, Result<Option<ResolvedWallpaperSource>, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<Option<ResolvedWallpaperSource>>> {
         Box::pin(async { Ok(None) })
     }
 }

--- a/ui/crates/platform_host_web/src/adapters.rs
+++ b/ui/crates/platform_host_web/src/adapters.rs
@@ -10,10 +10,10 @@ use platform_host::{
     AppStateEnvelope, AppStateStore, AppStateStoreFuture, ContentCache, ContentCacheFuture,
     ExplorerBackendStatus, ExplorerFileReadResult, ExplorerFsFuture, ExplorerFsService,
     ExplorerListResult, ExplorerMetadata, ExplorerPermissionMode, ExplorerPermissionState,
-    ExternalUrlFuture, ExternalUrlService, HostCapabilities, HostServices, HostStrategy,
-    NoopAppStateStore, NoopContentCache, NoopExplorerFsService, NoopExternalUrlService,
-    NoopNotificationService, NoopPrefsStore, NoopWallpaperAssetService, NotificationFuture,
-    NotificationService, PrefsStore, PrefsStoreFuture, ResolvedWallpaperSource,
+    ExternalUrlFuture, ExternalUrlService, HostCapabilities, HostResult, HostServices,
+    HostStrategy, NoopAppStateStore, NoopContentCache, NoopExplorerFsService,
+    NoopExternalUrlService, NoopNotificationService, NoopPrefsStore, NoopWallpaperAssetService,
+    NotificationFuture, NotificationService, PrefsStore, PrefsStoreFuture, ResolvedWallpaperSource,
     WallpaperAssetDeleteResult, WallpaperAssetFuture, WallpaperAssetMetadataPatch,
     WallpaperAssetRecord, WallpaperAssetService, WallpaperCollection,
     WallpaperCollectionDeleteResult, WallpaperImportRequest, WallpaperImportResult,
@@ -56,7 +56,7 @@ impl AppStateStore for AppStateStoreAdapter {
     fn load_app_state_envelope<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<Option<AppStateEnvelope>, String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<Option<AppStateEnvelope>>> {
         match self {
             Self::Browser(store) => store.load_app_state_envelope(namespace),
             Self::DesktopTauri(store) => store.load_app_state_envelope(namespace),
@@ -67,7 +67,7 @@ impl AppStateStore for AppStateStoreAdapter {
     fn save_app_state_envelope<'a>(
         &'a self,
         envelope: &'a AppStateEnvelope,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(store) => store.save_app_state_envelope(envelope),
             Self::DesktopTauri(store) => store.save_app_state_envelope(envelope),
@@ -78,7 +78,7 @@ impl AppStateStore for AppStateStoreAdapter {
     fn delete_app_state<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(store) => store.delete_app_state(namespace),
             Self::DesktopTauri(store) => store.delete_app_state(namespace),
@@ -86,9 +86,7 @@ impl AppStateStore for AppStateStoreAdapter {
         }
     }
 
-    fn list_app_state_namespaces<'a>(
-        &'a self,
-    ) -> AppStateStoreFuture<'a, Result<Vec<String>, String>> {
+    fn list_app_state_namespaces<'a>(&'a self) -> AppStateStoreFuture<'a, HostResult<Vec<String>>> {
         match self {
             Self::Browser(store) => store.list_app_state_namespaces(),
             Self::DesktopTauri(store) => store.list_app_state_namespaces(),
@@ -114,7 +112,7 @@ impl ContentCache for ContentCacheAdapter {
         cache_name: &'a str,
         key: &'a str,
         value: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(store) => store.put_text(cache_name, key, value),
             Self::DesktopTauri(store) => store.put_text(cache_name, key, value),
@@ -126,7 +124,7 @@ impl ContentCache for ContentCacheAdapter {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<Option<String>, String>> {
+    ) -> ContentCacheFuture<'a, HostResult<Option<String>>> {
         match self {
             Self::Browser(store) => store.get_text(cache_name, key),
             Self::DesktopTauri(store) => store.get_text(cache_name, key),
@@ -138,7 +136,7 @@ impl ContentCache for ContentCacheAdapter {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(store) => store.delete(cache_name, key),
             Self::DesktopTauri(store) => store.delete(cache_name, key),
@@ -160,7 +158,7 @@ pub enum ExplorerFsServiceAdapter {
 }
 
 impl ExplorerFsService for ExplorerFsServiceAdapter {
-    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         match self {
             Self::Browser(store) => store.status(),
             Self::DesktopTauri(store) => store.status(),
@@ -170,7 +168,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
 
     fn pick_native_directory<'a>(
         &'a self,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         match self {
             Self::Browser(store) => store.pick_native_directory(),
             Self::DesktopTauri(store) => store.pick_native_directory(),
@@ -181,7 +179,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
     fn request_permission<'a>(
         &'a self,
         mode: ExplorerPermissionMode,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerPermissionState, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerPermissionState>> {
         match self {
             Self::Browser(store) => store.request_permission(mode),
             Self::DesktopTauri(store) => store.request_permission(mode),
@@ -192,7 +190,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
     fn list_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerListResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerListResult>> {
         match self {
             Self::Browser(store) => store.list_dir(path),
             Self::DesktopTauri(store) => store.list_dir(path),
@@ -203,7 +201,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
     fn read_text_file<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerFileReadResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerFileReadResult>> {
         match self {
             Self::Browser(store) => store.read_text_file(path),
             Self::DesktopTauri(store) => store.read_text_file(path),
@@ -215,7 +213,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         match self {
             Self::Browser(store) => store.write_text_file(path, text),
             Self::DesktopTauri(store) => store.write_text_file(path, text),
@@ -226,7 +224,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
     fn create_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         match self {
             Self::Browser(store) => store.create_dir(path),
             Self::DesktopTauri(store) => store.create_dir(path),
@@ -238,7 +236,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         match self {
             Self::Browser(store) => store.create_file(path, text),
             Self::DesktopTauri(store) => store.create_file(path, text),
@@ -250,7 +248,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
         &'a self,
         path: &'a str,
         recursive: bool,
-    ) -> ExplorerFsFuture<'a, Result<(), String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(store) => store.delete(path, recursive),
             Self::DesktopTauri(store) => store.delete(path, recursive),
@@ -258,7 +256,7 @@ impl ExplorerFsService for ExplorerFsServiceAdapter {
         }
     }
 
-    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         match self {
             Self::Browser(store) => store.stat(path),
             Self::DesktopTauri(store) => store.stat(path),
@@ -279,7 +277,7 @@ pub enum ExternalUrlServiceAdapter {
 }
 
 impl ExternalUrlService for ExternalUrlServiceAdapter {
-    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, Result<(), String>> {
+    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(service) => service.open_url(url),
             Self::DesktopTauri(service) => service.open_url(url),
@@ -302,10 +300,7 @@ pub enum PrefsStoreAdapter {
 impl PrefsStoreAdapter {}
 
 impl PrefsStore for PrefsStoreAdapter {
-    fn load_pref<'a>(
-        &'a self,
-        key: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<Option<String>, String>> {
+    fn load_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<Option<String>>> {
         match self {
             Self::Browser(store) => store.load_pref(key),
             Self::DesktopTauri(store) => store.load_pref(key),
@@ -317,7 +312,7 @@ impl PrefsStore for PrefsStoreAdapter {
         &'a self,
         key: &'a str,
         raw_json: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<(), String>> {
+    ) -> PrefsStoreFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(store) => store.save_pref(key, raw_json),
             Self::DesktopTauri(store) => store.save_pref(key, raw_json),
@@ -325,7 +320,7 @@ impl PrefsStore for PrefsStoreAdapter {
         }
     }
 
-    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, Result<(), String>> {
+    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(store) => store.delete_pref(key),
             Self::DesktopTauri(store) => store.delete_pref(key),
@@ -351,7 +346,7 @@ impl NotificationService for NotificationServiceAdapter {
         &'a self,
         title: &'a str,
         body: &'a str,
-    ) -> NotificationFuture<'a, Result<(), String>> {
+    ) -> NotificationFuture<'a, HostResult<()>> {
         match self {
             Self::Browser(service) => service.notify(title, body),
             Self::DesktopTauri(service) => service.notify(title, body),
@@ -376,7 +371,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
     fn import_from_picker<'a>(
         &'a self,
         request: WallpaperImportRequest,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperImportResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperImportResult>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => {
                 service.import_from_picker(request)
@@ -387,7 +382,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
 
     fn list_library<'a>(
         &'a self,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperLibrarySnapshot, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperLibrarySnapshot>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => service.list_library(),
             Self::DesktopStub(service) => service.list_library(),
@@ -398,7 +393,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
         &'a self,
         asset_id: &'a str,
         patch: WallpaperAssetMetadataPatch,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetRecord, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetRecord>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => {
                 service.update_asset_metadata(asset_id, patch)
@@ -410,7 +405,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
     fn create_collection<'a>(
         &'a self,
         display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => {
                 service.create_collection(display_name)
@@ -423,7 +418,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
         &'a self,
         collection_id: &'a str,
         display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => {
                 service.rename_collection(collection_id, display_name)
@@ -435,7 +430,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
     fn delete_collection<'a>(
         &'a self,
         collection_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollectionDeleteResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollectionDeleteResult>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => {
                 service.delete_collection(collection_id)
@@ -447,7 +442,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
     fn delete_asset<'a>(
         &'a self,
         asset_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetDeleteResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetDeleteResult>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => service.delete_asset(asset_id),
             Self::DesktopStub(service) => service.delete_asset(asset_id),
@@ -457,7 +452,7 @@ impl WallpaperAssetService for WallpaperAssetServiceAdapter {
     fn resolve_source<'a>(
         &'a self,
         selection: WallpaperSelection,
-    ) -> WallpaperAssetFuture<'a, Result<Option<ResolvedWallpaperSource>, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<Option<ResolvedWallpaperSource>>> {
         match self {
             Self::Browser(service) | Self::DesktopTauri(service) => {
                 service.resolve_source(selection)

--- a/ui/crates/platform_host_web/src/bridge/app_state.rs
+++ b/ui/crates/platform_host_web/src/bridge/app_state.rs
@@ -1,19 +1,19 @@
-use platform_host::AppStateEnvelope;
+use platform_host::{AppStateEnvelope, HostResult};
 
 pub(crate) async fn load_app_state_envelope(
     namespace: &str,
-) -> Result<Option<AppStateEnvelope>, String> {
+) -> HostResult<Option<AppStateEnvelope>> {
     super::interop::load_app_state_envelope(namespace).await
 }
 
-pub(crate) async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> Result<(), String> {
+pub(crate) async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> HostResult<()> {
     super::interop::save_app_state_envelope(envelope).await
 }
 
-pub(crate) async fn delete_app_state(namespace: &str) -> Result<(), String> {
+pub(crate) async fn delete_app_state(namespace: &str) -> HostResult<()> {
     super::interop::delete_app_state(namespace).await
 }
 
-pub(crate) async fn list_app_state_namespaces() -> Result<Vec<String>, String> {
+pub(crate) async fn list_app_state_namespaces() -> HostResult<Vec<String>> {
     super::interop::list_app_state_namespaces().await
 }

--- a/ui/crates/platform_host_web/src/bridge/cache.rs
+++ b/ui/crates/platform_host_web/src/bridge/cache.rs
@@ -1,11 +1,13 @@
-pub(crate) async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> Result<(), String> {
+use platform_host::HostResult;
+
+pub(crate) async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> HostResult<()> {
     super::interop::cache_put_text(cache_name, key, value).await
 }
 
-pub(crate) async fn cache_get_text(cache_name: &str, key: &str) -> Result<Option<String>, String> {
+pub(crate) async fn cache_get_text(cache_name: &str, key: &str) -> HostResult<Option<String>> {
     super::interop::cache_get_text(cache_name, key).await
 }
 
-pub(crate) async fn cache_delete(cache_name: &str, key: &str) -> Result<(), String> {
+pub(crate) async fn cache_delete(cache_name: &str, key: &str) -> HostResult<()> {
     super::interop::cache_delete(cache_name, key).await
 }

--- a/ui/crates/platform_host_web/src/bridge/fs.rs
+++ b/ui/crates/platform_host_web/src/bridge/fs.rs
@@ -1,52 +1,49 @@
 use platform_host::{
     ExplorerBackendStatus, ExplorerFileReadResult, ExplorerListResult, ExplorerMetadata,
-    ExplorerPermissionMode, ExplorerPermissionState,
+    ExplorerPermissionMode, ExplorerPermissionState, HostResult,
 };
 
-pub(crate) async fn explorer_status() -> Result<ExplorerBackendStatus, String> {
+pub(crate) async fn explorer_status() -> HostResult<ExplorerBackendStatus> {
     super::interop::explorer_status().await
 }
 
-pub(crate) async fn explorer_pick_native_directory() -> Result<ExplorerBackendStatus, String> {
+pub(crate) async fn explorer_pick_native_directory() -> HostResult<ExplorerBackendStatus> {
     super::interop::explorer_pick_native_directory().await
 }
 
 pub(crate) async fn explorer_request_permission(
     mode: ExplorerPermissionMode,
-) -> Result<ExplorerPermissionState, String> {
+) -> HostResult<ExplorerPermissionState> {
     super::interop::explorer_request_permission(mode).await
 }
 
-pub(crate) async fn explorer_list_dir(path: &str) -> Result<ExplorerListResult, String> {
+pub(crate) async fn explorer_list_dir(path: &str) -> HostResult<ExplorerListResult> {
     super::interop::explorer_list_dir(path).await
 }
 
-pub(crate) async fn explorer_read_text_file(path: &str) -> Result<ExplorerFileReadResult, String> {
+pub(crate) async fn explorer_read_text_file(path: &str) -> HostResult<ExplorerFileReadResult> {
     super::interop::explorer_read_text_file(path).await
 }
 
 pub(crate) async fn explorer_write_text_file(
     path: &str,
     text: &str,
-) -> Result<ExplorerMetadata, String> {
+) -> HostResult<ExplorerMetadata> {
     super::interop::explorer_write_text_file(path, text).await
 }
 
-pub(crate) async fn explorer_create_dir(path: &str) -> Result<ExplorerMetadata, String> {
+pub(crate) async fn explorer_create_dir(path: &str) -> HostResult<ExplorerMetadata> {
     super::interop::explorer_create_dir(path).await
 }
 
-pub(crate) async fn explorer_create_file(
-    path: &str,
-    text: &str,
-) -> Result<ExplorerMetadata, String> {
+pub(crate) async fn explorer_create_file(path: &str, text: &str) -> HostResult<ExplorerMetadata> {
     super::interop::explorer_create_file(path, text).await
 }
 
-pub(crate) async fn explorer_delete(path: &str, recursive: bool) -> Result<(), String> {
+pub(crate) async fn explorer_delete(path: &str, recursive: bool) -> HostResult<()> {
     super::interop::explorer_delete(path, recursive).await
 }
 
-pub(crate) async fn explorer_stat(path: &str) -> Result<ExplorerMetadata, String> {
+pub(crate) async fn explorer_stat(path: &str) -> HostResult<ExplorerMetadata> {
     super::interop::explorer_stat(path).await
 }

--- a/ui/crates/platform_host_web/src/bridge/interop/mod.rs
+++ b/ui/crates/platform_host_web/src/bridge/interop/mod.rs
@@ -5,7 +5,7 @@
 
 use platform_host::{
     AppStateEnvelope, ExplorerBackendStatus, ExplorerFileReadResult, ExplorerListResult,
-    ExplorerMetadata, ExplorerPermissionMode, ExplorerPermissionState,
+    ExplorerMetadata, ExplorerPermissionMode, ExplorerPermissionState, HostResult,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -18,92 +18,92 @@ use non_wasm as imp;
 #[cfg(target_arch = "wasm32")]
 use wasm as imp;
 
-pub async fn load_app_state_envelope(namespace: &str) -> Result<Option<AppStateEnvelope>, String> {
+pub async fn load_app_state_envelope(namespace: &str) -> HostResult<Option<AppStateEnvelope>> {
     imp::load_app_state_envelope(namespace).await
 }
 
-pub async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> Result<(), String> {
+pub async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> HostResult<()> {
     imp::save_app_state_envelope(envelope).await
 }
 
-pub async fn delete_app_state(namespace: &str) -> Result<(), String> {
+pub async fn delete_app_state(namespace: &str) -> HostResult<()> {
     imp::delete_app_state(namespace).await
 }
 
-pub async fn list_app_state_namespaces() -> Result<Vec<String>, String> {
+pub async fn list_app_state_namespaces() -> HostResult<Vec<String>> {
     imp::list_app_state_namespaces().await
 }
 
-pub async fn load_pref(key: &str) -> Result<Option<String>, String> {
+pub async fn load_pref(key: &str) -> HostResult<Option<String>> {
     imp::load_pref(key).await
 }
 
-pub async fn save_pref(key: &str, raw_json: &str) -> Result<(), String> {
+pub async fn save_pref(key: &str, raw_json: &str) -> HostResult<()> {
     imp::save_pref(key, raw_json).await
 }
 
-pub async fn delete_pref(key: &str) -> Result<(), String> {
+pub async fn delete_pref(key: &str) -> HostResult<()> {
     imp::delete_pref(key).await
 }
 
-pub async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> Result<(), String> {
+pub async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> HostResult<()> {
     imp::cache_put_text(cache_name, key, value).await
 }
 
-pub async fn cache_get_text(cache_name: &str, key: &str) -> Result<Option<String>, String> {
+pub async fn cache_get_text(cache_name: &str, key: &str) -> HostResult<Option<String>> {
     imp::cache_get_text(cache_name, key).await
 }
 
-pub async fn cache_delete(cache_name: &str, key: &str) -> Result<(), String> {
+pub async fn cache_delete(cache_name: &str, key: &str) -> HostResult<()> {
     imp::cache_delete(cache_name, key).await
 }
 
-pub async fn explorer_status() -> Result<ExplorerBackendStatus, String> {
+pub async fn explorer_status() -> HostResult<ExplorerBackendStatus> {
     imp::explorer_status().await
 }
 
-pub async fn explorer_pick_native_directory() -> Result<ExplorerBackendStatus, String> {
+pub async fn explorer_pick_native_directory() -> HostResult<ExplorerBackendStatus> {
     imp::explorer_pick_native_directory().await
 }
 
 pub async fn explorer_request_permission(
     mode: ExplorerPermissionMode,
-) -> Result<ExplorerPermissionState, String> {
+) -> HostResult<ExplorerPermissionState> {
     imp::explorer_request_permission(mode).await
 }
 
-pub async fn explorer_list_dir(path: &str) -> Result<ExplorerListResult, String> {
+pub async fn explorer_list_dir(path: &str) -> HostResult<ExplorerListResult> {
     imp::explorer_list_dir(path).await
 }
 
-pub async fn explorer_read_text_file(path: &str) -> Result<ExplorerFileReadResult, String> {
+pub async fn explorer_read_text_file(path: &str) -> HostResult<ExplorerFileReadResult> {
     imp::explorer_read_text_file(path).await
 }
 
-pub async fn explorer_write_text_file(path: &str, text: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_write_text_file(path: &str, text: &str) -> HostResult<ExplorerMetadata> {
     imp::explorer_write_text_file(path, text).await
 }
 
-pub async fn explorer_create_dir(path: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_create_dir(path: &str) -> HostResult<ExplorerMetadata> {
     imp::explorer_create_dir(path).await
 }
 
-pub async fn explorer_create_file(path: &str, text: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_create_file(path: &str, text: &str) -> HostResult<ExplorerMetadata> {
     imp::explorer_create_file(path, text).await
 }
 
-pub async fn explorer_delete(path: &str, recursive: bool) -> Result<(), String> {
+pub async fn explorer_delete(path: &str, recursive: bool) -> HostResult<()> {
     imp::explorer_delete(path, recursive).await
 }
 
-pub async fn explorer_stat(path: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_stat(path: &str) -> HostResult<ExplorerMetadata> {
     imp::explorer_stat(path).await
 }
 
-pub async fn open_external_url(url: &str) -> Result<(), String> {
+pub async fn open_external_url(url: &str) -> HostResult<()> {
     imp::open_external_url(url).await
 }
 
-pub async fn send_notification(title: &str, body: &str) -> Result<(), String> {
+pub async fn send_notification(title: &str, body: &str) -> HostResult<()> {
     imp::send_notification(title, body).await
 }

--- a/ui/crates/platform_host_web/src/bridge/interop/non_wasm.rs
+++ b/ui/crates/platform_host_web/src/bridge/interop/non_wasm.rs
@@ -1,98 +1,110 @@
 use super::*;
+use platform_host::{
+    ExternalUrlErrorKind, FsErrorKind, HostError, HostResult, NotificationErrorKind,
+};
 
-fn unsupported() -> String {
-    "Browser storage APIs are only available when compiled for wasm32".to_string()
+fn unsupported_fs(operation: &str) -> HostError {
+    HostError::fs(
+        FsErrorKind::Unsupported,
+        "Browser storage APIs are only available when compiled for wasm32",
+    )
+    .with_operation(operation)
 }
 
-pub async fn load_app_state_envelope(_namespace: &str) -> Result<Option<AppStateEnvelope>, String> {
+pub async fn load_app_state_envelope(_namespace: &str) -> HostResult<Option<AppStateEnvelope>> {
     Ok(None)
 }
 
-pub async fn save_app_state_envelope(_envelope: &AppStateEnvelope) -> Result<(), String> {
+pub async fn save_app_state_envelope(_envelope: &AppStateEnvelope) -> HostResult<()> {
     Ok(())
 }
 
-pub async fn delete_app_state(_namespace: &str) -> Result<(), String> {
+pub async fn delete_app_state(_namespace: &str) -> HostResult<()> {
     Ok(())
 }
 
-pub async fn list_app_state_namespaces() -> Result<Vec<String>, String> {
+pub async fn list_app_state_namespaces() -> HostResult<Vec<String>> {
     Ok(Vec::new())
 }
 
-pub async fn load_pref(_key: &str) -> Result<Option<String>, String> {
+pub async fn load_pref(_key: &str) -> HostResult<Option<String>> {
     Ok(None)
 }
 
-pub async fn save_pref(_key: &str, _raw_json: &str) -> Result<(), String> {
+pub async fn save_pref(_key: &str, _raw_json: &str) -> HostResult<()> {
     Ok(())
 }
 
-pub async fn delete_pref(_key: &str) -> Result<(), String> {
+pub async fn delete_pref(_key: &str) -> HostResult<()> {
     Ok(())
 }
 
-pub async fn cache_put_text(_cache_name: &str, _key: &str, _value: &str) -> Result<(), String> {
+pub async fn cache_put_text(_cache_name: &str, _key: &str, _value: &str) -> HostResult<()> {
     Ok(())
 }
 
-pub async fn cache_get_text(_cache_name: &str, _key: &str) -> Result<Option<String>, String> {
+pub async fn cache_get_text(_cache_name: &str, _key: &str) -> HostResult<Option<String>> {
     Ok(None)
 }
 
-pub async fn cache_delete(_cache_name: &str, _key: &str) -> Result<(), String> {
+pub async fn cache_delete(_cache_name: &str, _key: &str) -> HostResult<()> {
     Ok(())
 }
 
-pub async fn explorer_status() -> Result<ExplorerBackendStatus, String> {
-    Err(unsupported())
+pub async fn explorer_status() -> HostResult<ExplorerBackendStatus> {
+    Err(unsupported_fs("explorer.status"))
 }
 
-pub async fn explorer_pick_native_directory() -> Result<ExplorerBackendStatus, String> {
-    Err(unsupported())
+pub async fn explorer_pick_native_directory() -> HostResult<ExplorerBackendStatus> {
+    Err(unsupported_fs("explorer.pick_native_directory"))
 }
 
 pub async fn explorer_request_permission(
     _mode: ExplorerPermissionMode,
-) -> Result<ExplorerPermissionState, String> {
-    Err(unsupported())
+) -> HostResult<ExplorerPermissionState> {
+    Err(unsupported_fs("explorer.request_permission"))
 }
 
-pub async fn explorer_list_dir(_path: &str) -> Result<ExplorerListResult, String> {
-    Err(unsupported())
+pub async fn explorer_list_dir(_path: &str) -> HostResult<ExplorerListResult> {
+    Err(unsupported_fs("explorer.list_dir"))
 }
 
-pub async fn explorer_read_text_file(_path: &str) -> Result<ExplorerFileReadResult, String> {
-    Err(unsupported())
+pub async fn explorer_read_text_file(_path: &str) -> HostResult<ExplorerFileReadResult> {
+    Err(unsupported_fs("explorer.read_text_file"))
 }
 
-pub async fn explorer_write_text_file(
-    _path: &str,
-    _text: &str,
-) -> Result<ExplorerMetadata, String> {
-    Err(unsupported())
+pub async fn explorer_write_text_file(_path: &str, _text: &str) -> HostResult<ExplorerMetadata> {
+    Err(unsupported_fs("explorer.write_text_file"))
 }
 
-pub async fn explorer_create_dir(_path: &str) -> Result<ExplorerMetadata, String> {
-    Err(unsupported())
+pub async fn explorer_create_dir(_path: &str) -> HostResult<ExplorerMetadata> {
+    Err(unsupported_fs("explorer.create_dir"))
 }
 
-pub async fn explorer_create_file(_path: &str, _text: &str) -> Result<ExplorerMetadata, String> {
-    Err(unsupported())
+pub async fn explorer_create_file(_path: &str, _text: &str) -> HostResult<ExplorerMetadata> {
+    Err(unsupported_fs("explorer.create_file"))
 }
 
-pub async fn explorer_delete(_path: &str, _recursive: bool) -> Result<(), String> {
-    Err(unsupported())
+pub async fn explorer_delete(_path: &str, _recursive: bool) -> HostResult<()> {
+    Err(unsupported_fs("explorer.delete"))
 }
 
-pub async fn explorer_stat(_path: &str) -> Result<ExplorerMetadata, String> {
-    Err(unsupported())
+pub async fn explorer_stat(_path: &str) -> HostResult<ExplorerMetadata> {
+    Err(unsupported_fs("explorer.stat"))
 }
 
-pub async fn open_external_url(_url: &str) -> Result<(), String> {
-    Err(unsupported())
+pub async fn open_external_url(_url: &str) -> HostResult<()> {
+    Err(HostError::external_url(
+        ExternalUrlErrorKind::Unsupported,
+        "External URL opening is unavailable in non-wasm preview mode",
+    )
+    .with_operation("external_url.open"))
 }
 
-pub async fn send_notification(_title: &str, _body: &str) -> Result<(), String> {
-    Err(unsupported())
+pub async fn send_notification(_title: &str, _body: &str) -> HostResult<()> {
+    Err(HostError::notification(
+        NotificationErrorKind::Unsupported,
+        "Notifications are unavailable in non-wasm preview mode",
+    )
+    .with_operation("notification.notify"))
 }

--- a/ui/crates/platform_host_web/src/bridge/interop/wasm.rs
+++ b/ui/crates/platform_host_web/src/bridge/interop/wasm.rs
@@ -6,7 +6,10 @@ use serde_wasm_bindgen::{from_value, Serializer};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use platform_host::ExplorerPermissionMode;
+use platform_host::{
+    CacheErrorKind, ExplorerPermissionMode, ExternalUrlErrorKind, FsErrorKind, HostError,
+    HostResult, NotificationErrorKind, StorageErrorKind,
+};
 
 #[wasm_bindgen(inline_js = r#"
 const DB_NAME = 'retrodesk_os';
@@ -971,6 +974,24 @@ async fn await_promise(promise: Promise) -> Result<JsValue, String> {
     JsFuture::from(promise).await.map_err(js_error_to_string)
 }
 
+fn storage_error(kind: StorageErrorKind, operation: &str, detail: impl Into<String>) -> HostError {
+    HostError::storage(kind, "Browser storage request failed")
+        .with_operation(operation)
+        .with_internal(detail.into())
+}
+
+fn cache_error(kind: CacheErrorKind, operation: &str, detail: impl Into<String>) -> HostError {
+    HostError::cache(kind, "Browser cache request failed")
+        .with_operation(operation)
+        .with_internal(detail.into())
+}
+
+fn fs_error(kind: FsErrorKind, operation: &str, detail: impl Into<String>) -> HostError {
+    HostError::fs(kind, "Browser filesystem request failed")
+        .with_operation(operation)
+        .with_internal(detail.into())
+}
+
 fn js_error_to_string(err: JsValue) -> String {
     if let Some(text) = err.as_string() {
         return text;
@@ -999,129 +1020,207 @@ async fn promise_to_optional_json<T: DeserializeOwned>(
     }
 }
 
-pub async fn load_app_state_envelope(namespace: &str) -> Result<Option<AppStateEnvelope>, String> {
-    promise_to_optional_json(js_app_state_load(namespace)).await
+pub async fn load_app_state_envelope(namespace: &str) -> HostResult<Option<AppStateEnvelope>> {
+    promise_to_optional_json(js_app_state_load(namespace))
+        .await
+        .map_err(|err| storage_error(StorageErrorKind::Load, "app_state.load", err))
 }
 
-pub async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> Result<(), String> {
+pub async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> HostResult<()> {
     let value = envelope
         .serialize(&Serializer::json_compatible())
-        .map_err(|e| e.to_string())?;
-    let _ = await_promise(js_app_state_save(value)).await?;
+        .map_err(|err| {
+            storage_error(
+                StorageErrorKind::Serialize,
+                "app_state.save",
+                err.to_string(),
+            )
+        })?;
+    let _ = await_promise(js_app_state_save(value))
+        .await
+        .map_err(|err| storage_error(StorageErrorKind::Save, "app_state.save", err))?;
     Ok(())
 }
 
-pub async fn delete_app_state(namespace: &str) -> Result<(), String> {
-    let _ = await_promise(js_app_state_delete(namespace)).await?;
+pub async fn delete_app_state(namespace: &str) -> HostResult<()> {
+    let _ = await_promise(js_app_state_delete(namespace))
+        .await
+        .map_err(|err| storage_error(StorageErrorKind::Delete, "app_state.delete", err))?;
     Ok(())
 }
 
-pub async fn list_app_state_namespaces() -> Result<Vec<String>, String> {
-    promise_to_json(js_app_state_namespaces()).await
+pub async fn list_app_state_namespaces() -> HostResult<Vec<String>> {
+    promise_to_json(js_app_state_namespaces())
+        .await
+        .map_err(|err| storage_error(StorageErrorKind::List, "app_state.list", err))
 }
 
-pub async fn load_pref(key: &str) -> Result<Option<String>, String> {
-    let value = await_promise(js_prefs_load(key)).await?;
+pub async fn load_pref(key: &str) -> HostResult<Option<String>> {
+    let value = await_promise(js_prefs_load(key))
+        .await
+        .map_err(|err| storage_error(StorageErrorKind::Load, "prefs.load", err))?;
     if value.is_null() || value.is_undefined() {
         Ok(None)
     } else {
-        value
-            .as_string()
-            .map(Some)
-            .ok_or_else(|| "Prefs API returned non-string payload".to_string())
+        value.as_string().map(Some).ok_or_else(|| {
+            storage_error(
+                StorageErrorKind::Deserialize,
+                "prefs.load",
+                "Prefs API returned non-string payload",
+            )
+        })
     }
 }
 
-pub async fn save_pref(key: &str, raw_json: &str) -> Result<(), String> {
-    let _ = await_promise(js_prefs_save(key, raw_json)).await?;
+pub async fn save_pref(key: &str, raw_json: &str) -> HostResult<()> {
+    let _ = await_promise(js_prefs_save(key, raw_json))
+        .await
+        .map_err(|err| storage_error(StorageErrorKind::Save, "prefs.save", err))?;
     Ok(())
 }
 
-pub async fn delete_pref(key: &str) -> Result<(), String> {
-    let _ = await_promise(js_prefs_delete(key)).await?;
+pub async fn delete_pref(key: &str) -> HostResult<()> {
+    let _ = await_promise(js_prefs_delete(key))
+        .await
+        .map_err(|err| storage_error(StorageErrorKind::Delete, "prefs.delete", err))?;
     Ok(())
 }
 
-pub async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> Result<(), String> {
-    let _ = await_promise(js_cache_put_text(cache_name, key, value)).await?;
+pub async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> HostResult<()> {
+    let _ = await_promise(js_cache_put_text(cache_name, key, value))
+        .await
+        .map_err(|err| cache_error(CacheErrorKind::Put, "cache.put", err))?;
     Ok(())
 }
 
-pub async fn cache_get_text(cache_name: &str, key: &str) -> Result<Option<String>, String> {
-    let value = await_promise(js_cache_get_text(cache_name, key)).await?;
+pub async fn cache_get_text(cache_name: &str, key: &str) -> HostResult<Option<String>> {
+    let value = await_promise(js_cache_get_text(cache_name, key))
+        .await
+        .map_err(|err| cache_error(CacheErrorKind::Get, "cache.get", err))?;
     if value.is_null() || value.is_undefined() {
         Ok(None)
     } else {
-        value
-            .as_string()
-            .map(Some)
-            .ok_or_else(|| "Cache API returned non-string payload".to_string())
+        value.as_string().map(Some).ok_or_else(|| {
+            cache_error(
+                CacheErrorKind::Deserialize,
+                "cache.get",
+                "Cache API returned non-string payload",
+            )
+        })
     }
 }
 
-pub async fn cache_delete(cache_name: &str, key: &str) -> Result<(), String> {
-    let _ = await_promise(js_cache_delete(cache_name, key)).await?;
+pub async fn cache_delete(cache_name: &str, key: &str) -> HostResult<()> {
+    let _ = await_promise(js_cache_delete(cache_name, key))
+        .await
+        .map_err(|err| cache_error(CacheErrorKind::Delete, "cache.delete", err))?;
     Ok(())
 }
 
-pub async fn explorer_status() -> Result<ExplorerBackendStatus, String> {
-    promise_to_json(js_explorer_status()).await
+pub async fn explorer_status() -> HostResult<ExplorerBackendStatus> {
+    promise_to_json(js_explorer_status())
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Status, "explorer.status", err))
 }
 
-pub async fn explorer_pick_native_directory() -> Result<ExplorerBackendStatus, String> {
-    promise_to_json(js_explorer_pick_native_directory()).await
+pub async fn explorer_pick_native_directory() -> HostResult<ExplorerBackendStatus> {
+    promise_to_json(js_explorer_pick_native_directory())
+        .await
+        .map_err(|err| {
+            fs_error(
+                FsErrorKind::Permission,
+                "explorer.pick_native_directory",
+                err,
+            )
+        })
 }
 
 pub async fn explorer_request_permission(
     mode: ExplorerPermissionMode,
-) -> Result<ExplorerPermissionState, String> {
+) -> HostResult<ExplorerPermissionState> {
     let mode = match mode {
         ExplorerPermissionMode::Read => "read",
         ExplorerPermissionMode::Readwrite => "readwrite",
     };
-    promise_to_json(js_explorer_request_permission(mode)).await
+    promise_to_json(js_explorer_request_permission(mode))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Permission, "explorer.request_permission", err))
 }
 
-pub async fn explorer_list_dir(path: &str) -> Result<ExplorerListResult, String> {
-    promise_to_json(js_explorer_list_dir(path)).await
+pub async fn explorer_list_dir(path: &str) -> HostResult<ExplorerListResult> {
+    promise_to_json(js_explorer_list_dir(path))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Read, "explorer.list_dir", err))
 }
 
-pub async fn explorer_read_text_file(path: &str) -> Result<ExplorerFileReadResult, String> {
-    promise_to_json(js_explorer_read_text_file(path)).await
+pub async fn explorer_read_text_file(path: &str) -> HostResult<ExplorerFileReadResult> {
+    promise_to_json(js_explorer_read_text_file(path))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Read, "explorer.read_text_file", err))
 }
 
-pub async fn explorer_write_text_file(path: &str, text: &str) -> Result<ExplorerMetadata, String> {
-    promise_to_json(js_explorer_write_text_file(path, text)).await
+pub async fn explorer_write_text_file(path: &str, text: &str) -> HostResult<ExplorerMetadata> {
+    promise_to_json(js_explorer_write_text_file(path, text))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Write, "explorer.write_text_file", err))
 }
 
-pub async fn explorer_create_dir(path: &str) -> Result<ExplorerMetadata, String> {
-    promise_to_json(js_explorer_create_dir(path)).await
+pub async fn explorer_create_dir(path: &str) -> HostResult<ExplorerMetadata> {
+    promise_to_json(js_explorer_create_dir(path))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Create, "explorer.create_dir", err))
 }
 
-pub async fn explorer_create_file(path: &str, text: &str) -> Result<ExplorerMetadata, String> {
-    promise_to_json(js_explorer_create_file(path, text)).await
+pub async fn explorer_create_file(path: &str, text: &str) -> HostResult<ExplorerMetadata> {
+    promise_to_json(js_explorer_create_file(path, text))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Create, "explorer.create_file", err))
 }
 
-pub async fn explorer_delete(path: &str, recursive: bool) -> Result<(), String> {
-    let _ = await_promise(js_explorer_delete(path, recursive)).await?;
+pub async fn explorer_delete(path: &str, recursive: bool) -> HostResult<()> {
+    let _ = await_promise(js_explorer_delete(path, recursive))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Delete, "explorer.delete", err))?;
     Ok(())
 }
 
-pub async fn explorer_stat(path: &str) -> Result<ExplorerMetadata, String> {
-    promise_to_json(js_explorer_stat(path)).await
+pub async fn explorer_stat(path: &str) -> HostResult<ExplorerMetadata> {
+    promise_to_json(js_explorer_stat(path))
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Stat, "explorer.stat", err))
 }
 
 #[allow(dead_code)]
-pub async fn explorer_clear_native_root() -> Result<ExplorerBackendStatus, String> {
-    promise_to_json(js_explorer_clear_native_root()).await
+pub async fn explorer_clear_native_root() -> HostResult<ExplorerBackendStatus> {
+    promise_to_json(js_explorer_clear_native_root())
+        .await
+        .map_err(|err| fs_error(FsErrorKind::Permission, "explorer.clear_native_root", err))
 }
 
-pub async fn open_external_url(url: &str) -> Result<(), String> {
-    let _ = await_promise(js_open_external_url(url)).await?;
+pub async fn open_external_url(url: &str) -> HostResult<()> {
+    let _ = await_promise(js_open_external_url(url))
+        .await
+        .map_err(|err| {
+            HostError::external_url(
+                ExternalUrlErrorKind::Open,
+                "External URL could not be opened",
+            )
+            .with_operation("external_url.open")
+            .with_internal(err)
+        })?;
     Ok(())
 }
 
-pub async fn send_notification(title: &str, body: &str) -> Result<(), String> {
-    let _ = await_promise(js_notify_send(title, body)).await?;
+pub async fn send_notification(title: &str, body: &str) -> HostResult<()> {
+    let _ = await_promise(js_notify_send(title, body))
+        .await
+        .map_err(|err| {
+            HostError::notification(
+                NotificationErrorKind::Dispatch,
+                "Notification could not be delivered",
+            )
+            .with_operation("notification.notify")
+            .with_internal(err)
+        })?;
     Ok(())
 }

--- a/ui/crates/platform_host_web/src/bridge/mod.rs
+++ b/ui/crates/platform_host_web/src/bridge/mod.rs
@@ -11,106 +11,117 @@ mod prefs;
 
 use platform_host::{
     AppStateEnvelope, ExplorerBackendStatus, ExplorerFileReadResult, ExplorerListResult,
-    ExplorerMetadata, ExplorerPermissionMode, ExplorerPermissionState,
+    ExplorerMetadata, ExplorerPermissionMode, ExplorerPermissionState, HostResult,
 };
 
-pub async fn load_app_state_envelope(namespace: &str) -> Result<Option<AppStateEnvelope>, String> {
+pub async fn load_app_state_envelope(namespace: &str) -> HostResult<Option<AppStateEnvelope>> {
     app_state::load_app_state_envelope(namespace).await
 }
 
-pub async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> Result<(), String> {
+pub async fn save_app_state_envelope(envelope: &AppStateEnvelope) -> HostResult<()> {
     app_state::save_app_state_envelope(envelope).await
 }
 
-pub async fn delete_app_state(namespace: &str) -> Result<(), String> {
+pub async fn delete_app_state(namespace: &str) -> HostResult<()> {
     app_state::delete_app_state(namespace).await
 }
 
-pub async fn list_app_state_namespaces() -> Result<Vec<String>, String> {
+pub async fn list_app_state_namespaces() -> HostResult<Vec<String>> {
     app_state::list_app_state_namespaces().await
 }
 
-pub async fn load_pref(key: &str) -> Result<Option<String>, String> {
+pub async fn load_pref(key: &str) -> HostResult<Option<String>> {
     prefs::load_pref(key).await
 }
 
-pub async fn save_pref(key: &str, raw_json: &str) -> Result<(), String> {
+pub async fn save_pref(key: &str, raw_json: &str) -> HostResult<()> {
     prefs::save_pref(key, raw_json).await
 }
 
-pub async fn delete_pref(key: &str) -> Result<(), String> {
+pub async fn delete_pref(key: &str) -> HostResult<()> {
     prefs::delete_pref(key).await
 }
 
-pub async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> Result<(), String> {
+pub async fn cache_put_text(cache_name: &str, key: &str, value: &str) -> HostResult<()> {
     cache::cache_put_text(cache_name, key, value).await
 }
 
-pub async fn cache_get_text(cache_name: &str, key: &str) -> Result<Option<String>, String> {
+pub async fn cache_get_text(cache_name: &str, key: &str) -> HostResult<Option<String>> {
     cache::cache_get_text(cache_name, key).await
 }
 
-pub async fn cache_delete(cache_name: &str, key: &str) -> Result<(), String> {
+pub async fn cache_delete(cache_name: &str, key: &str) -> HostResult<()> {
     cache::cache_delete(cache_name, key).await
 }
 
-pub async fn explorer_status() -> Result<ExplorerBackendStatus, String> {
+pub async fn explorer_status() -> HostResult<ExplorerBackendStatus> {
     fs::explorer_status().await
 }
 
-pub async fn explorer_pick_native_directory() -> Result<ExplorerBackendStatus, String> {
+pub async fn explorer_pick_native_directory() -> HostResult<ExplorerBackendStatus> {
     fs::explorer_pick_native_directory().await
 }
 
 pub async fn explorer_request_permission(
     mode: ExplorerPermissionMode,
-) -> Result<ExplorerPermissionState, String> {
+) -> HostResult<ExplorerPermissionState> {
     fs::explorer_request_permission(mode).await
 }
 
-pub async fn explorer_list_dir(path: &str) -> Result<ExplorerListResult, String> {
+pub async fn explorer_list_dir(path: &str) -> HostResult<ExplorerListResult> {
     fs::explorer_list_dir(path).await
 }
 
-pub async fn explorer_read_text_file(path: &str) -> Result<ExplorerFileReadResult, String> {
+pub async fn explorer_read_text_file(path: &str) -> HostResult<ExplorerFileReadResult> {
     fs::explorer_read_text_file(path).await
 }
 
-pub async fn explorer_write_text_file(path: &str, text: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_write_text_file(path: &str, text: &str) -> HostResult<ExplorerMetadata> {
     fs::explorer_write_text_file(path, text).await
 }
 
-pub async fn explorer_create_dir(path: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_create_dir(path: &str) -> HostResult<ExplorerMetadata> {
     fs::explorer_create_dir(path).await
 }
 
-pub async fn explorer_create_file(path: &str, text: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_create_file(path: &str, text: &str) -> HostResult<ExplorerMetadata> {
     fs::explorer_create_file(path, text).await
 }
 
-pub async fn explorer_delete(path: &str, recursive: bool) -> Result<(), String> {
+pub async fn explorer_delete(path: &str, recursive: bool) -> HostResult<()> {
     fs::explorer_delete(path, recursive).await
 }
 
-pub async fn explorer_stat(path: &str) -> Result<ExplorerMetadata, String> {
+pub async fn explorer_stat(path: &str) -> HostResult<ExplorerMetadata> {
     fs::explorer_stat(path).await
 }
 
-pub async fn open_external_url(url: &str) -> Result<(), String> {
+pub async fn open_external_url(url: &str) -> HostResult<()> {
     interop::open_external_url(url).await
 }
 
-pub async fn send_notification(title: &str, body: &str) -> Result<(), String> {
+pub async fn send_notification(title: &str, body: &str) -> HostResult<()> {
     interop::send_notification(title, body).await
 }
 
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;
-    use platform_host::{AppStateEnvelope, ExplorerPermissionMode};
+    use platform_host::{
+        AppStateEnvelope, ExplorerPermissionMode, FsErrorKind, HostError, HostErrorKind,
+    };
     use serde_json::json;
 
     use super::*;
+
+    fn assert_non_wasm_fs_error(err: HostError, operation: &str) {
+        assert_eq!(err.kind, HostErrorKind::Fs(FsErrorKind::Unsupported));
+        assert_eq!(
+            err.safe_message,
+            "Browser storage APIs are only available when compiled for wasm32"
+        );
+        assert_eq!(err.metadata.operation.as_deref(), Some(operation));
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
@@ -160,51 +171,48 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn fs_public_api_non_wasm_parity() {
-        let expected =
-            "Browser storage APIs are only available when compiled for wasm32".to_string();
-
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_status()).expect_err("status should fail"),
-            expected
+            "explorer.status",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_pick_native_directory()).expect_err("pick should fail"),
-            expected
+            "explorer.pick_native_directory",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_request_permission(ExplorerPermissionMode::Read))
                 .expect_err("permission should fail"),
-            expected
+            "explorer.request_permission",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_list_dir("/")).expect_err("list should fail"),
-            expected
+            "explorer.list_dir",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_read_text_file("/readme.txt")).expect_err("read should fail"),
-            expected
+            "explorer.read_text_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_write_text_file("/readme.txt", "text"))
                 .expect_err("write should fail"),
-            expected
+            "explorer.write_text_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_create_dir("/Docs")).expect_err("create dir should fail"),
-            expected
+            "explorer.create_dir",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_create_file("/Docs/new.txt", "text"))
                 .expect_err("create file should fail"),
-            expected
+            "explorer.create_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_delete("/Docs/new.txt", false)).expect_err("delete should fail"),
-            expected
+            "explorer.delete",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(explorer_stat("/Docs")).expect_err("stat should fail"),
-            expected
+            "explorer.stat",
         );
     }
 }

--- a/ui/crates/platform_host_web/src/bridge/prefs.rs
+++ b/ui/crates/platform_host_web/src/bridge/prefs.rs
@@ -1,11 +1,13 @@
-pub(crate) async fn load_pref(key: &str) -> Result<Option<String>, String> {
+use platform_host::HostResult;
+
+pub(crate) async fn load_pref(key: &str) -> HostResult<Option<String>> {
     super::interop::load_pref(key).await
 }
 
-pub(crate) async fn save_pref(key: &str, raw_json: &str) -> Result<(), String> {
+pub(crate) async fn save_pref(key: &str, raw_json: &str) -> HostResult<()> {
     super::interop::save_pref(key, raw_json).await
 }
 
-pub(crate) async fn delete_pref(key: &str) -> Result<(), String> {
+pub(crate) async fn delete_pref(key: &str) -> HostResult<()> {
     super::interop::delete_pref(key).await
 }

--- a/ui/crates/platform_host_web/src/cache/cache_api.rs
+++ b/ui/crates/platform_host_web/src/cache/cache_api.rs
@@ -1,6 +1,6 @@
 //! Cache API-backed content cache implementation.
 
-use platform_host::{ContentCache, ContentCacheFuture};
+use platform_host::{ContentCache, ContentCacheFuture, HostResult};
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Browser content cache backed by the Cache API.
@@ -12,7 +12,7 @@ impl ContentCache for WebContentCache {
         cache_name: &'a str,
         key: &'a str,
         value: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::cache_put_text(cache_name, key, value).await })
     }
 
@@ -20,7 +20,7 @@ impl ContentCache for WebContentCache {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<Option<String>, String>> {
+    ) -> ContentCacheFuture<'a, HostResult<Option<String>>> {
         Box::pin(async move { crate::bridge::cache_get_text(cache_name, key).await })
     }
 
@@ -28,7 +28,7 @@ impl ContentCache for WebContentCache {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::cache_delete(cache_name, key).await })
     }
 }

--- a/ui/crates/platform_host_web/src/cache/tauri_cache_api.rs
+++ b/ui/crates/platform_host_web/src/cache/tauri_cache_api.rs
@@ -1,6 +1,6 @@
 //! Tauri command-backed content cache implementation.
 
-use platform_host::{ContentCache, ContentCacheFuture};
+use platform_host::{ContentCache, ContentCacheFuture, HostResult};
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Desktop content cache backed by Tauri command transport.
@@ -12,7 +12,7 @@ impl ContentCache for TauriContentCache {
         cache_name: &'a str,
         key: &'a str,
         value: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::cache_put_text(cache_name, key, value).await })
     }
 
@@ -20,7 +20,7 @@ impl ContentCache for TauriContentCache {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<Option<String>, String>> {
+    ) -> ContentCacheFuture<'a, HostResult<Option<String>>> {
         Box::pin(async move { crate::bridge::cache_get_text(cache_name, key).await })
     }
 
@@ -28,7 +28,7 @@ impl ContentCache for TauriContentCache {
         &'a self,
         cache_name: &'a str,
         key: &'a str,
-    ) -> ContentCacheFuture<'a, Result<(), String>> {
+    ) -> ContentCacheFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::cache_delete(cache_name, key).await })
     }
 }

--- a/ui/crates/platform_host_web/src/external_url.rs
+++ b/ui/crates/platform_host_web/src/external_url.rs
@@ -1,6 +1,6 @@
 //! External URL host-service adapters for browser and desktop-webview contexts.
 
-use platform_host::{ExternalUrlFuture, ExternalUrlService};
+use platform_host::{ExternalUrlFuture, ExternalUrlService, HostResult};
 
 use crate::bridge;
 
@@ -9,7 +9,7 @@ use crate::bridge;
 pub struct WebExternalUrlService;
 
 impl ExternalUrlService for WebExternalUrlService {
-    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, Result<(), String>> {
+    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, HostResult<()>> {
         Box::pin(async move { bridge::open_external_url(url).await })
     }
 }
@@ -19,7 +19,7 @@ impl ExternalUrlService for WebExternalUrlService {
 pub struct TauriExternalUrlService;
 
 impl ExternalUrlService for TauriExternalUrlService {
-    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, Result<(), String>> {
+    fn open_url<'a>(&'a self, url: &'a str) -> ExternalUrlFuture<'a, HostResult<()>> {
         Box::pin(async move { bridge::open_external_url(url).await })
     }
 }

--- a/ui/crates/platform_host_web/src/fs/explorer.rs
+++ b/ui/crates/platform_host_web/src/fs/explorer.rs
@@ -3,6 +3,7 @@
 use platform_host::{
     ExplorerBackendStatus, ExplorerFileReadResult, ExplorerFsFuture, ExplorerFsService,
     ExplorerListResult, ExplorerMetadata, ExplorerPermissionMode, ExplorerPermissionState,
+    HostResult,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -10,34 +11,34 @@ use platform_host::{
 pub struct WebExplorerFsService;
 
 impl ExplorerFsService for WebExplorerFsService {
-    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         Box::pin(async move { crate::bridge::explorer_status().await })
     }
 
     fn pick_native_directory<'a>(
         &'a self,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         Box::pin(async move { crate::bridge::explorer_pick_native_directory().await })
     }
 
     fn request_permission<'a>(
         &'a self,
         mode: ExplorerPermissionMode,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerPermissionState, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerPermissionState>> {
         Box::pin(async move { crate::bridge::explorer_request_permission(mode).await })
     }
 
     fn list_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerListResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerListResult>> {
         Box::pin(async move { crate::bridge::explorer_list_dir(path).await })
     }
 
     fn read_text_file<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerFileReadResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerFileReadResult>> {
         Box::pin(async move { crate::bridge::explorer_read_text_file(path).await })
     }
 
@@ -45,14 +46,14 @@ impl ExplorerFsService for WebExplorerFsService {
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_write_text_file(path, text).await })
     }
 
     fn create_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_create_dir(path).await })
     }
 
@@ -60,7 +61,7 @@ impl ExplorerFsService for WebExplorerFsService {
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_create_file(path, text).await })
     }
 
@@ -68,11 +69,11 @@ impl ExplorerFsService for WebExplorerFsService {
         &'a self,
         path: &'a str,
         recursive: bool,
-    ) -> ExplorerFsFuture<'a, Result<(), String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::explorer_delete(path, recursive).await })
     }
 
-    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_stat(path).await })
     }
 }
@@ -82,34 +83,34 @@ impl ExplorerFsService for WebExplorerFsService {
 pub struct TauriExplorerFsService;
 
 impl ExplorerFsService for TauriExplorerFsService {
-    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    fn status<'a>(&'a self) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         Box::pin(async move { crate::bridge::explorer_status().await })
     }
 
     fn pick_native_directory<'a>(
         &'a self,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerBackendStatus, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerBackendStatus>> {
         Box::pin(async move { crate::bridge::explorer_pick_native_directory().await })
     }
 
     fn request_permission<'a>(
         &'a self,
         mode: ExplorerPermissionMode,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerPermissionState, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerPermissionState>> {
         Box::pin(async move { crate::bridge::explorer_request_permission(mode).await })
     }
 
     fn list_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerListResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerListResult>> {
         Box::pin(async move { crate::bridge::explorer_list_dir(path).await })
     }
 
     fn read_text_file<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerFileReadResult, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerFileReadResult>> {
         Box::pin(async move { crate::bridge::explorer_read_text_file(path).await })
     }
 
@@ -117,14 +118,14 @@ impl ExplorerFsService for TauriExplorerFsService {
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_write_text_file(path, text).await })
     }
 
     fn create_dir<'a>(
         &'a self,
         path: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_create_dir(path).await })
     }
 
@@ -132,7 +133,7 @@ impl ExplorerFsService for TauriExplorerFsService {
         &'a self,
         path: &'a str,
         text: &'a str,
-    ) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_create_file(path, text).await })
     }
 
@@ -140,11 +141,11 @@ impl ExplorerFsService for TauriExplorerFsService {
         &'a self,
         path: &'a str,
         recursive: bool,
-    ) -> ExplorerFsFuture<'a, Result<(), String>> {
+    ) -> ExplorerFsFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::explorer_delete(path, recursive).await })
     }
 
-    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, Result<ExplorerMetadata, String>> {
+    fn stat<'a>(&'a self, path: &'a str) -> ExplorerFsFuture<'a, HostResult<ExplorerMetadata>> {
         Box::pin(async move { crate::bridge::explorer_stat(path).await })
     }
 }
@@ -152,53 +153,64 @@ impl ExplorerFsService for TauriExplorerFsService {
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;
+    use platform_host::{FsErrorKind, HostError, HostErrorKind};
 
     use super::*;
+
+    fn assert_non_wasm_fs_error(err: HostError, operation: &str) {
+        assert_eq!(err.kind, HostErrorKind::Fs(FsErrorKind::Unsupported));
+        assert_eq!(
+            err.safe_message,
+            "Browser storage APIs are only available when compiled for wasm32"
+        );
+        assert_eq!(err.metadata.operation.as_deref(), Some(operation));
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn non_wasm_explorer_adapter_matches_bridge_fallback_behavior() {
         let fs = WebExplorerFsService;
         let fs_obj: &dyn ExplorerFsService = &fs;
-        let expected = "Browser storage APIs are only available when compiled for wasm32";
-
-        assert_eq!(block_on(fs_obj.status()).expect_err("status"), expected);
-        assert_eq!(
-            block_on(fs_obj.pick_native_directory()).expect_err("pick native dir"),
-            expected
+        assert_non_wasm_fs_error(
+            block_on(fs_obj.status()).expect_err("status"),
+            "explorer.status",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
+            block_on(fs_obj.pick_native_directory()).expect_err("pick native dir"),
+            "explorer.pick_native_directory",
+        );
+        assert_non_wasm_fs_error(
             block_on(fs_obj.request_permission(ExplorerPermissionMode::Read))
                 .expect_err("request permission"),
-            expected
+            "explorer.request_permission",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.list_dir("/")).expect_err("list dir"),
-            expected
+            "explorer.list_dir",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.read_text_file("/demo.txt")).expect_err("read file"),
-            expected
+            "explorer.read_text_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.write_text_file("/demo.txt", "text")).expect_err("write file"),
-            expected
+            "explorer.write_text_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.create_dir("/Demo")).expect_err("create dir"),
-            expected
+            "explorer.create_dir",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.create_file("/Demo/new.txt", "text")).expect_err("create file"),
-            expected
+            "explorer.create_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.delete("/Demo/new.txt", false)).expect_err("delete"),
-            expected
+            "explorer.delete",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.stat("/Demo/new.txt")).expect_err("stat"),
-            expected
+            "explorer.stat",
         );
     }
 
@@ -207,45 +219,46 @@ mod tests {
     fn non_wasm_tauri_explorer_adapter_matches_bridge_fallback_behavior() {
         let fs = TauriExplorerFsService;
         let fs_obj: &dyn ExplorerFsService = &fs;
-        let expected = "Browser storage APIs are only available when compiled for wasm32";
-
-        assert_eq!(block_on(fs_obj.status()).expect_err("status"), expected);
-        assert_eq!(
-            block_on(fs_obj.pick_native_directory()).expect_err("pick native dir"),
-            expected
+        assert_non_wasm_fs_error(
+            block_on(fs_obj.status()).expect_err("status"),
+            "explorer.status",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
+            block_on(fs_obj.pick_native_directory()).expect_err("pick native dir"),
+            "explorer.pick_native_directory",
+        );
+        assert_non_wasm_fs_error(
             block_on(fs_obj.request_permission(ExplorerPermissionMode::Read))
                 .expect_err("request permission"),
-            expected
+            "explorer.request_permission",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.list_dir("/")).expect_err("list dir"),
-            expected
+            "explorer.list_dir",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.read_text_file("/demo.txt")).expect_err("read file"),
-            expected
+            "explorer.read_text_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.write_text_file("/demo.txt", "text")).expect_err("write file"),
-            expected
+            "explorer.write_text_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.create_dir("/Demo")).expect_err("create dir"),
-            expected
+            "explorer.create_dir",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.create_file("/Demo/new.txt", "text")).expect_err("create file"),
-            expected
+            "explorer.create_file",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.delete("/Demo/new.txt", false)).expect_err("delete"),
-            expected
+            "explorer.delete",
         );
-        assert_eq!(
+        assert_non_wasm_fs_error(
             block_on(fs_obj.stat("/Demo/new.txt")).expect_err("stat"),
-            expected
+            "explorer.stat",
         );
     }
 }

--- a/ui/crates/platform_host_web/src/notifications.rs
+++ b/ui/crates/platform_host_web/src/notifications.rs
@@ -1,7 +1,7 @@
 //! Notification host-service adapters for browser and desktop-webview contexts.
 
 use crate::bridge;
-use platform_host::{NotificationFuture, NotificationService};
+use platform_host::{HostResult, NotificationFuture, NotificationService};
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Browser notification adapter backed by the Web Notifications API.
@@ -12,7 +12,7 @@ impl NotificationService for WebNotificationService {
         &'a self,
         title: &'a str,
         body: &'a str,
-    ) -> NotificationFuture<'a, Result<(), String>> {
+    ) -> NotificationFuture<'a, HostResult<()>> {
         Box::pin(async move {
             #[cfg(target_arch = "wasm32")]
             {
@@ -22,9 +22,16 @@ impl NotificationService for WebNotificationService {
                 } else {
                     format!("{title}: {body}")
                 };
-                return web_sys::Notification::new(&rendered)
-                    .map(|_| ())
-                    .map_err(|err: JsValue| format!("notification dispatch failed: {err:?}"));
+                return web_sys::Notification::new(&rendered).map(|_| ()).map_err(
+                    |err: JsValue| {
+                        platform_host::HostError::notification(
+                            platform_host::NotificationErrorKind::Dispatch,
+                            "Notification could not be delivered",
+                        )
+                        .with_operation("notification.notify")
+                        .with_internal(format!("{err:?}"))
+                    },
+                );
             }
 
             #[cfg(not(target_arch = "wasm32"))]
@@ -45,7 +52,7 @@ impl NotificationService for TauriNotificationService {
         &'a self,
         title: &'a str,
         body: &'a str,
-    ) -> NotificationFuture<'a, Result<(), String>> {
+    ) -> NotificationFuture<'a, HostResult<()>> {
         Box::pin(async move { bridge::send_notification(title, body).await })
     }
 }

--- a/ui/crates/platform_host_web/src/storage/indexed_db.rs
+++ b/ui/crates/platform_host_web/src/storage/indexed_db.rs
@@ -1,6 +1,6 @@
 //! IndexedDB-backed app-state store implementation.
 
-use platform_host::{AppStateEnvelope, AppStateStore, AppStateStoreFuture};
+use platform_host::{AppStateEnvelope, AppStateStore, AppStateStoreFuture, HostResult};
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Browser app-state store backed by IndexedDB.
@@ -10,27 +10,25 @@ impl AppStateStore for WebAppStateStore {
     fn load_app_state_envelope<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<Option<AppStateEnvelope>, String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<Option<AppStateEnvelope>>> {
         Box::pin(async move { crate::bridge::load_app_state_envelope(namespace).await })
     }
 
     fn save_app_state_envelope<'a>(
         &'a self,
         envelope: &'a AppStateEnvelope,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::save_app_state_envelope(envelope).await })
     }
 
     fn delete_app_state<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::delete_app_state(namespace).await })
     }
 
-    fn list_app_state_namespaces<'a>(
-        &'a self,
-    ) -> AppStateStoreFuture<'a, Result<Vec<String>, String>> {
+    fn list_app_state_namespaces<'a>(&'a self) -> AppStateStoreFuture<'a, HostResult<Vec<String>>> {
         Box::pin(async move { crate::bridge::list_app_state_namespaces().await })
     }
 }

--- a/ui/crates/platform_host_web/src/storage/local_prefs.rs
+++ b/ui/crates/platform_host_web/src/storage/local_prefs.rs
@@ -1,16 +1,13 @@
 //! Browser preference storage implementation backed by the shared async bridge.
 
-use platform_host::{PrefsStore, PrefsStoreFuture};
+use platform_host::{HostResult, PrefsStore, PrefsStoreFuture};
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Browser preference store backed by browser persistence through the shared bridge.
 pub struct WebPrefsStore;
 
 impl PrefsStore for WebPrefsStore {
-    fn load_pref<'a>(
-        &'a self,
-        key: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<Option<String>, String>> {
+    fn load_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<Option<String>>> {
         Box::pin(async move { crate::bridge::load_pref(key).await })
     }
 
@@ -18,11 +15,11 @@ impl PrefsStore for WebPrefsStore {
         &'a self,
         key: &'a str,
         raw_json: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<(), String>> {
+    ) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::save_pref(key, raw_json).await })
     }
 
-    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, Result<(), String>> {
+    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::delete_pref(key).await })
     }
 }

--- a/ui/crates/platform_host_web/src/storage/tauri_app_state.rs
+++ b/ui/crates/platform_host_web/src/storage/tauri_app_state.rs
@@ -3,7 +3,7 @@
 //! This store uses the bridge interop layer, which routes app-state calls to Tauri
 //! commands when available in desktop webview contexts.
 
-use platform_host::{AppStateEnvelope, AppStateStore, AppStateStoreFuture};
+use platform_host::{AppStateEnvelope, AppStateStore, AppStateStoreFuture, HostResult};
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Desktop app-state store backed by Tauri command transport.
@@ -13,27 +13,25 @@ impl AppStateStore for TauriAppStateStore {
     fn load_app_state_envelope<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<Option<AppStateEnvelope>, String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<Option<AppStateEnvelope>>> {
         Box::pin(async move { crate::bridge::load_app_state_envelope(namespace).await })
     }
 
     fn save_app_state_envelope<'a>(
         &'a self,
         envelope: &'a AppStateEnvelope,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::save_app_state_envelope(envelope).await })
     }
 
     fn delete_app_state<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> AppStateStoreFuture<'a, Result<(), String>> {
+    ) -> AppStateStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::delete_app_state(namespace).await })
     }
 
-    fn list_app_state_namespaces<'a>(
-        &'a self,
-    ) -> AppStateStoreFuture<'a, Result<Vec<String>, String>> {
+    fn list_app_state_namespaces<'a>(&'a self) -> AppStateStoreFuture<'a, HostResult<Vec<String>>> {
         Box::pin(async move { crate::bridge::list_app_state_namespaces().await })
     }
 }

--- a/ui/crates/platform_host_web/src/storage/tauri_prefs.rs
+++ b/ui/crates/platform_host_web/src/storage/tauri_prefs.rs
@@ -3,17 +3,14 @@
 //! This store uses the bridge interop layer, which routes preference calls to Tauri commands
 //! when available in desktop webview contexts.
 
-use platform_host::{PrefsStore, PrefsStoreFuture};
+use platform_host::{HostResult, PrefsStore, PrefsStoreFuture};
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Desktop preference store backed by Tauri command transport.
 pub struct TauriPrefsStore;
 
 impl PrefsStore for TauriPrefsStore {
-    fn load_pref<'a>(
-        &'a self,
-        key: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<Option<String>, String>> {
+    fn load_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<Option<String>>> {
         Box::pin(async move { crate::bridge::load_pref(key).await })
     }
 
@@ -21,11 +18,11 @@ impl PrefsStore for TauriPrefsStore {
         &'a self,
         key: &'a str,
         raw_json: &'a str,
-    ) -> PrefsStoreFuture<'a, Result<(), String>> {
+    ) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::save_pref(key, raw_json).await })
     }
 
-    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, Result<(), String>> {
+    fn delete_pref<'a>(&'a self, key: &'a str) -> PrefsStoreFuture<'a, HostResult<()>> {
         Box::pin(async move { crate::bridge::delete_pref(key).await })
     }
 }

--- a/ui/crates/platform_host_web/src/wallpaper.rs
+++ b/ui/crates/platform_host_web/src/wallpaper.rs
@@ -1,11 +1,12 @@
 //! Browser-backed wallpaper asset service implementation.
 
 use platform_host::{
-    build_app_state_envelope, migrate_envelope_payload, next_monotonic_timestamp_ms,
-    ResolvedWallpaperSource, WallpaperAssetDeleteResult, WallpaperAssetFuture,
+    build_app_state_envelope, migrate_envelope_payload, next_monotonic_timestamp_ms, HostError,
+    HostResult, ResolvedWallpaperSource, WallpaperAssetDeleteResult, WallpaperAssetFuture,
     WallpaperAssetMetadataPatch, WallpaperAssetRecord, WallpaperAssetService, WallpaperCollection,
-    WallpaperCollectionDeleteResult, WallpaperImportRequest, WallpaperImportResult,
-    WallpaperLibrarySnapshot, WallpaperMediaKind, WallpaperSelection, WallpaperSourceKind,
+    WallpaperCollectionDeleteResult, WallpaperErrorKind, WallpaperImportRequest,
+    WallpaperImportResult, WallpaperLibrarySnapshot, WallpaperMediaKind, WallpaperSelection,
+    WallpaperSourceKind,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -29,7 +30,7 @@ impl WallpaperAssetService for WebWallpaperAssetService {
     fn import_from_picker<'a>(
         &'a self,
         request: WallpaperImportRequest,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperImportResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperImportResult>> {
         Box::pin(async move {
             let picked = pick_file().await?;
             let library = load_library_snapshot().await?;
@@ -37,10 +38,12 @@ impl WallpaperAssetService for WebWallpaperAssetService {
             let mut next = library;
             next.used_bytes = next.used_bytes.saturating_add(record.byte_len);
             if next.used_bytes > next.soft_limit_bytes {
-                return Err(format!(
-                    "wallpaper library soft limit exceeded ({} > {})",
-                    next.used_bytes, next.soft_limit_bytes
-                ));
+                return Err(HostError::wallpaper(
+                    WallpaperErrorKind::Import,
+                    "Wallpaper library limit was exceeded",
+                )
+                .with_operation("wallpaper.import")
+                .with_internal(format!("{} > {}", next.used_bytes, next.soft_limit_bytes)));
             }
             next.assets.push(record.clone());
             save_library_snapshot(&next).await?;
@@ -54,7 +57,7 @@ impl WallpaperAssetService for WebWallpaperAssetService {
 
     fn list_library<'a>(
         &'a self,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperLibrarySnapshot, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperLibrarySnapshot>> {
         Box::pin(async move { load_library_snapshot().await })
     }
 
@@ -62,14 +65,21 @@ impl WallpaperAssetService for WebWallpaperAssetService {
         &'a self,
         asset_id: &'a str,
         patch: WallpaperAssetMetadataPatch,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetRecord, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetRecord>> {
         Box::pin(async move {
             let mut library = load_library_snapshot().await?;
             let asset = library
                 .assets
                 .iter_mut()
                 .find(|asset| asset.asset_id == asset_id)
-                .ok_or_else(|| format!("wallpaper asset not found: {asset_id}"))?;
+                .ok_or_else(|| {
+                    HostError::wallpaper(
+                        WallpaperErrorKind::Update,
+                        "Wallpaper asset could not be found",
+                    )
+                    .with_operation("wallpaper.update_asset_metadata")
+                    .with_internal(asset_id)
+                })?;
             if let Some(display_name) = patch.display_name {
                 asset.display_name = display_name;
             }
@@ -92,7 +102,7 @@ impl WallpaperAssetService for WebWallpaperAssetService {
     fn create_collection<'a>(
         &'a self,
         display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>> {
         Box::pin(async move {
             let mut library = load_library_snapshot().await?;
             let collection = WallpaperCollection {
@@ -110,14 +120,21 @@ impl WallpaperAssetService for WebWallpaperAssetService {
         &'a self,
         collection_id: &'a str,
         display_name: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollection, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollection>> {
         Box::pin(async move {
             let mut library = load_library_snapshot().await?;
             let collection = library
                 .collections
                 .iter_mut()
                 .find(|collection| collection.collection_id == collection_id)
-                .ok_or_else(|| format!("wallpaper collection not found: {collection_id}"))?;
+                .ok_or_else(|| {
+                    HostError::wallpaper(
+                        WallpaperErrorKind::RenameCollection,
+                        "Wallpaper collection could not be found",
+                    )
+                    .with_operation("wallpaper.rename_collection")
+                    .with_internal(collection_id)
+                })?;
             collection.display_name = display_name.trim().to_string();
             let updated = collection.clone();
             save_library_snapshot(&library).await?;
@@ -128,7 +145,7 @@ impl WallpaperAssetService for WebWallpaperAssetService {
     fn delete_collection<'a>(
         &'a self,
         collection_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperCollectionDeleteResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperCollectionDeleteResult>> {
         Box::pin(async move {
             let mut library = load_library_snapshot().await?;
             library
@@ -147,13 +164,18 @@ impl WallpaperAssetService for WebWallpaperAssetService {
     fn delete_asset<'a>(
         &'a self,
         asset_id: &'a str,
-    ) -> WallpaperAssetFuture<'a, Result<WallpaperAssetDeleteResult, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<WallpaperAssetDeleteResult>> {
         Box::pin(async move {
             let mut library = load_library_snapshot().await?;
             let before = library.assets.len();
             library.assets.retain(|asset| asset.asset_id != asset_id);
             if library.assets.len() == before {
-                return Err(format!("wallpaper asset not found: {asset_id}"));
+                return Err(HostError::wallpaper(
+                    WallpaperErrorKind::DeleteAsset,
+                    "Wallpaper asset could not be found",
+                )
+                .with_operation("wallpaper.delete_asset")
+                .with_internal(asset_id));
             }
             library.used_bytes = library.assets.iter().map(|asset| asset.byte_len).sum();
             save_library_snapshot(&library).await?;
@@ -167,7 +189,7 @@ impl WallpaperAssetService for WebWallpaperAssetService {
     fn resolve_source<'a>(
         &'a self,
         selection: WallpaperSelection,
-    ) -> WallpaperAssetFuture<'a, Result<Option<ResolvedWallpaperSource>, String>> {
+    ) -> WallpaperAssetFuture<'a, HostResult<Option<ResolvedWallpaperSource>>> {
         Box::pin(async move {
             match selection {
                 WallpaperSelection::BuiltIn { .. } => Ok(None),
@@ -202,17 +224,19 @@ struct PickedFile {
 fn build_import_record(
     picked: &PickedFile,
     request: WallpaperImportRequest,
-) -> Result<WallpaperAssetRecord, String> {
+) -> HostResult<WallpaperAssetRecord> {
     let media_kind = classify_media_kind(&picked.name, &picked.mime_type)?;
     let limit = match media_kind {
         WallpaperMediaKind::StaticImage | WallpaperMediaKind::Svg => STILL_IMAGE_LIMIT_BYTES,
         WallpaperMediaKind::AnimatedImage | WallpaperMediaKind::Video => ANIMATED_LIMIT_BYTES,
     };
     if picked.size > limit {
-        return Err(format!(
-            "selected wallpaper exceeds size limit ({} > {})",
-            picked.size, limit
-        ));
+        return Err(HostError::wallpaper(
+            WallpaperErrorKind::Import,
+            "Selected wallpaper exceeds the supported size limit",
+        )
+        .with_operation("wallpaper.import")
+        .with_internal(format!("{} > {}", picked.size, limit)));
     }
 
     let stem = picked
@@ -251,7 +275,7 @@ fn build_import_record(
     })
 }
 
-fn classify_media_kind(name: &str, mime_type: &str) -> Result<WallpaperMediaKind, String> {
+fn classify_media_kind(name: &str, mime_type: &str) -> HostResult<WallpaperMediaKind> {
     let extension = name
         .rsplit_once('.')
         .map(|(_, ext)| ext.to_ascii_lowercase())
@@ -264,11 +288,16 @@ fn classify_media_kind(name: &str, mime_type: &str) -> Result<WallpaperMediaKind
         _ if mime_type == "image/svg+xml" => Ok(WallpaperMediaKind::Svg),
         _ if mime_type.starts_with("image/") => Ok(WallpaperMediaKind::StaticImage),
         _ if mime_type.starts_with("video/") => Ok(WallpaperMediaKind::Video),
-        _ => Err(format!("unsupported wallpaper format: {name}")),
+        _ => Err(HostError::wallpaper(
+            WallpaperErrorKind::Import,
+            "Selected wallpaper format is not supported",
+        )
+        .with_operation("wallpaper.classify_media_kind")
+        .with_internal(name)),
     }
 }
 
-async fn load_library_snapshot() -> Result<WallpaperLibrarySnapshot, String> {
+async fn load_library_snapshot() -> HostResult<WallpaperLibrarySnapshot> {
     let Some(envelope) =
         crate::bridge::load_app_state_envelope(WALLPAPER_LIBRARY_NAMESPACE).await?
     else {
@@ -280,7 +309,7 @@ async fn load_library_snapshot() -> Result<WallpaperLibrarySnapshot, String> {
     migrate_envelope_payload::<WallpaperLibrarySnapshot>(&envelope)
 }
 
-async fn save_library_snapshot(snapshot: &WallpaperLibrarySnapshot) -> Result<(), String> {
+async fn save_library_snapshot(snapshot: &WallpaperLibrarySnapshot) -> HostResult<()> {
     let envelope = build_app_state_envelope(
         WALLPAPER_LIBRARY_NAMESPACE,
         WALLPAPER_LIBRARY_SCHEMA_VERSION,
@@ -289,23 +318,50 @@ async fn save_library_snapshot(snapshot: &WallpaperLibrarySnapshot) -> Result<()
     crate::bridge::save_app_state_envelope(&envelope).await
 }
 
-async fn pick_file() -> Result<PickedFile, String> {
+async fn pick_file() -> HostResult<PickedFile> {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        Err("wallpaper import is only available when compiled for wasm32".to_string())
+        Err(HostError::wallpaper(
+            WallpaperErrorKind::Unsupported,
+            "Wallpaper import is only available in wasm builds",
+        )
+        .with_operation("wallpaper.pick_file"))
     }
 
     #[cfg(target_arch = "wasm32")]
     {
-        let window = web_sys::window().ok_or_else(|| "window unavailable".to_string())?;
-        let document = window
-            .document()
-            .ok_or_else(|| "document unavailable".to_string())?;
+        let window = web_sys::window().ok_or_else(|| {
+            HostError::wallpaper(
+                WallpaperErrorKind::Import,
+                "Browser window is unavailable for wallpaper import",
+            )
+            .with_operation("wallpaper.pick_file")
+        })?;
+        let document = window.document().ok_or_else(|| {
+            HostError::wallpaper(
+                WallpaperErrorKind::Import,
+                "Browser document is unavailable for wallpaper import",
+            )
+            .with_operation("wallpaper.pick_file")
+        })?;
         let input = document
             .create_element("input")
-            .map_err(|err| format!("failed to create file input: {err:?}"))?
+            .map_err(|err| {
+                HostError::wallpaper(
+                    WallpaperErrorKind::Import,
+                    "Wallpaper file picker could not be created",
+                )
+                .with_operation("wallpaper.pick_file")
+                .with_internal(format!("{err:?}"))
+            })?
             .dyn_into::<web_sys::HtmlInputElement>()
-            .map_err(|_| "failed to cast file input".to_string())?;
+            .map_err(|_| {
+                HostError::wallpaper(
+                    WallpaperErrorKind::Import,
+                    "Wallpaper file picker could not be initialized",
+                )
+                .with_operation("wallpaper.pick_file")
+            })?;
         input.set_type("file");
         input.set_accept(
             "image/png,image/jpeg,image/webp,image/svg+xml,image/gif,video/mp4,video/webm",
@@ -316,7 +372,7 @@ async fn pick_file() -> Result<PickedFile, String> {
             let _ = body.append_child(&input);
         }
 
-        let (tx, rx) = oneshot::channel::<Result<web_sys::File, String>>();
+        let (tx, rx) = oneshot::channel::<HostResult<web_sys::File>>();
         let sender = Rc::new(RefCell::new(Some(tx)));
         let input_for_change = input.clone();
         let change_sender = sender.clone();
@@ -324,7 +380,13 @@ async fn pick_file() -> Result<PickedFile, String> {
             let result = input_for_change
                 .files()
                 .and_then(|files| files.get(0))
-                .ok_or_else(|| "no wallpaper file selected".to_string());
+                .ok_or_else(|| {
+                    HostError::wallpaper(
+                        WallpaperErrorKind::Import,
+                        "No wallpaper file was selected",
+                    )
+                    .with_operation("wallpaper.pick_file")
+                });
             if let Some(tx) = change_sender.borrow_mut().take() {
                 let _ = tx.send(result);
             }
@@ -332,9 +394,10 @@ async fn pick_file() -> Result<PickedFile, String> {
         input.set_onchange(Some(on_change.as_ref().unchecked_ref()));
         input.click();
 
-        let file = rx
-            .await
-            .map_err(|_| "wallpaper picker was cancelled".to_string())??;
+        let file = rx.await.map_err(|_| {
+            HostError::wallpaper(WallpaperErrorKind::Import, "Wallpaper picker was cancelled")
+                .with_operation("wallpaper.pick_file")
+        })??;
         input.remove();
         on_change.forget();
 
@@ -349,9 +412,16 @@ async fn pick_file() -> Result<PickedFile, String> {
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn read_file_as_data_url(file: &web_sys::File) -> Result<String, String> {
-    let reader = web_sys::FileReader::new().map_err(|err| format!("{err:?}"))?;
-    let (tx, rx) = oneshot::channel::<Result<String, String>>();
+async fn read_file_as_data_url(file: &web_sys::File) -> HostResult<String> {
+    let reader = web_sys::FileReader::new().map_err(|err| {
+        HostError::wallpaper(
+            WallpaperErrorKind::Import,
+            "Wallpaper file could not be read",
+        )
+        .with_operation("wallpaper.read_file")
+        .with_internal(format!("{err:?}"))
+    })?;
+    let (tx, rx) = oneshot::channel::<HostResult<String>>();
     let sender = Rc::new(RefCell::new(Some(tx)));
 
     let reader_for_load = reader.clone();
@@ -359,11 +429,22 @@ async fn read_file_as_data_url(file: &web_sys::File) -> Result<String, String> {
     let on_load = Closure::<dyn FnMut(web_sys::ProgressEvent)>::wrap(Box::new(move |_| {
         let result = reader_for_load
             .result()
-            .map_err(|err| format!("failed to read wallpaper file: {err:?}"))
+            .map_err(|err| {
+                HostError::wallpaper(
+                    WallpaperErrorKind::Import,
+                    "Wallpaper file could not be read",
+                )
+                .with_operation("wallpaper.read_file")
+                .with_internal(format!("{err:?}"))
+            })
             .and_then(|value| {
-                value
-                    .as_string()
-                    .ok_or_else(|| "file reader returned non-string result".to_string())
+                value.as_string().ok_or_else(|| {
+                    HostError::wallpaper(
+                        WallpaperErrorKind::Import,
+                        "Wallpaper file reader returned invalid data",
+                    )
+                    .with_operation("wallpaper.read_file")
+                })
             });
         if let Some(tx) = load_sender.borrow_mut().take() {
             let _ = tx.send(result);
@@ -374,18 +455,31 @@ async fn read_file_as_data_url(file: &web_sys::File) -> Result<String, String> {
     let error_sender = sender.clone();
     let on_error = Closure::<dyn FnMut(web_sys::ProgressEvent)>::wrap(Box::new(move |_| {
         if let Some(tx) = error_sender.borrow_mut().take() {
-            let _ = tx.send(Err("failed to load wallpaper file".to_string()));
+            let _ = tx.send(Err(HostError::wallpaper(
+                WallpaperErrorKind::Import,
+                "Wallpaper file could not be loaded",
+            )
+            .with_operation("wallpaper.read_file")));
         }
     }));
     reader.set_onerror(Some(on_error.as_ref().unchecked_ref()));
 
-    reader
-        .read_as_data_url(file)
-        .map_err(|err| format!("failed to start file read: {err:?}"))?;
+    reader.read_as_data_url(file).map_err(|err| {
+        HostError::wallpaper(
+            WallpaperErrorKind::Import,
+            "Wallpaper file read could not be started",
+        )
+        .with_operation("wallpaper.read_file")
+        .with_internal(format!("{err:?}"))
+    })?;
 
-    let result = rx
-        .await
-        .map_err(|_| "wallpaper file read was interrupted".to_string())?;
+    let result = rx.await.map_err(|_| {
+        HostError::wallpaper(
+            WallpaperErrorKind::Import,
+            "Wallpaper file read was interrupted",
+        )
+        .with_operation("wallpaper.read_file")
+    })?;
     on_load.forget();
     on_error.forget();
     result

--- a/ui/crates/site/Cargo.toml
+++ b/ui/crates/site/Cargo.toml
@@ -24,6 +24,9 @@ leptos_meta = { version = "0.6", default-features = false }
 leptos_router = { version = "0.6", default-features = false }
 platform_host_web = { path = "../platform_host_web", default-features = false }
 js-sys = "0.3"
+telemetry = { path = "../../../shared/telemetry" }
+tracing.workspace = true
+tracing-wasm = "0.2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["BroadcastChannel", "Document", "Location", "MessageEvent", "Navigator", "ServiceWorkerContainer", "Url", "Window"] }

--- a/ui/crates/site/src/lib.rs
+++ b/ui/crates/site/src/lib.rs
@@ -15,21 +15,81 @@ mod web_app;
 pub use web_app::{DesktopEntry, SiteApp};
 
 #[cfg(all(feature = "csr", target_arch = "wasm32"))]
+fn init_site_tracing() {
+    use std::sync::Once;
+
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        tracing_wasm::set_as_global_default();
+    });
+
+    tracing::info!(
+        event = "site.mount.bootstrap",
+        operation = "site.mount",
+        component = "site",
+        runtime_target = %telemetry::RuntimeTarget::Wasm.as_str(),
+        environment = %if cfg!(debug_assertions) {
+            telemetry::EnvironmentProfile::Development.as_str()
+        } else {
+            telemetry::EnvironmentProfile::Production.as_str()
+        }
+    );
+}
+
+#[cfg(all(feature = "csr", target_arch = "wasm32"))]
 /// Mounts [`SiteApp`] into the dedicated application root for client-side rendering.
 ///
 /// This is the browser entrypoint used by the `site_app` binary when built for `wasm32` with the
 /// `csr` feature enabled.
 pub fn mount() {
+    init_site_tracing();
     console_error_panic_hook::set_once();
     use wasm_bindgen::JsCast;
 
-    let document = web_sys::window()
-        .and_then(|window| window.document())
-        .expect("window document should be available for CSR mount");
-    let app_root = document
-        .get_element_by_id("app")
-        .expect("site app root element should exist")
-        .dyn_into::<web_sys::HtmlElement>()
-        .expect("site app root should be an HtmlElement");
+    let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+        tracing::error!(
+            event = "site.mount.failed",
+            operation = "site.mount",
+            component = "site",
+            runtime_target = %telemetry::RuntimeTarget::Wasm.as_str(),
+            environment = %if cfg!(debug_assertions) {
+                telemetry::EnvironmentProfile::Development.as_str()
+            } else {
+                telemetry::EnvironmentProfile::Production.as_str()
+            },
+            reason = "window_document_unavailable"
+        );
+        return;
+    };
+    let Some(app_root) = document.get_element_by_id("app") else {
+        tracing::error!(
+            event = "site.mount.failed",
+            operation = "site.mount",
+            component = "site",
+            runtime_target = %telemetry::RuntimeTarget::Wasm.as_str(),
+            environment = %if cfg!(debug_assertions) {
+                telemetry::EnvironmentProfile::Development.as_str()
+            } else {
+                telemetry::EnvironmentProfile::Production.as_str()
+            },
+            reason = "app_root_missing"
+        );
+        return;
+    };
+    let Ok(app_root) = app_root.dyn_into::<web_sys::HtmlElement>() else {
+        tracing::error!(
+            event = "site.mount.failed",
+            operation = "site.mount",
+            component = "site",
+            runtime_target = %telemetry::RuntimeTarget::Wasm.as_str(),
+            environment = %if cfg!(debug_assertions) {
+                telemetry::EnvironmentProfile::Development.as_str()
+            } else {
+                telemetry::EnvironmentProfile::Production.as_str()
+            },
+            reason = "app_root_not_html_element"
+        );
+        return;
+    };
     leptos::mount_to(app_root, || leptos::view! { <SiteApp /> })
 }

--- a/ui/crates/site/src/main.rs
+++ b/ui/crates/site/src/main.rs
@@ -7,7 +7,12 @@ fn main() {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    eprintln!(
-        "This binary is intended for the browser/WASM workflow. Use `cargo ui-dev` for preview builds or build `site_app` for wasm32 with the `csr` feature."
+    tracing::error!(
+        event = "site.main.unsupported_target",
+        operation = "site.main",
+        component = "site",
+        runtime_target = "desktop",
+        environment = %if cfg!(debug_assertions) { "development" } else { "production" },
+        message = "This binary is intended for the browser/WASM workflow. Use `cargo ui-dev` for preview builds or build `site_app` for wasm32 with the `csr` feature."
     );
 }


### PR DESCRIPTION
## Summary
- add shared typed error and telemetry primitives for the UI workspace
- replace stringly typed host boundary errors with `HostError` and `HostResult<T>` across the relevant UI crates
- standardize `tracing`-based observability for desktop and wasm targets and document the UI observability contract

## Testing
- cargo check -p desktop_runtime
- cargo check -p site
- cargo check -p desktop_tauri
- cargo ui-build
- cargo verify-ui

## Deployment Impact
- updates UI-only runtime, host adapter, and documentation behavior
- no direct service or infrastructure rollout changes

Closes #68
