### PR TITLE
docs(governance): codify issue branch PR workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,29 @@ cargo test --workspace --all-targets
 - Contract or schema changes MUST include compatibility tests or fixture updates.
 - CI failures block merge; no bypass without documented incident approval.
 
+## GitHub Workflow Protocol
+- Every material code, docs, schema, workflow, or infrastructure change MUST begin with a same-repository GitHub issue before implementation starts.
+- The issue is the system of record and MUST include:
+  - a concise summary of the proposed change, defect, or enhancement,
+  - background and scope,
+  - acceptance criteria,
+  - implementation notes, constraints, or linked context when needed.
+- Work MUST proceed on a dedicated short-lived branch created from the latest `main`.
+- Branch names MUST follow `<type>/<issue-id>-<short-kebab-summary>`.
+- Approved branch type prefixes are:
+  - `feature/`
+  - `fix/`
+  - `docs/`
+  - `refactor/`
+  - `infra/`
+  - `research/`
+- Each branch MUST map to one primary issue and MUST reference the GitHub issue identifier in the branch name.
+- Pull requests MUST target `main`, reference the originating issue, and include a closing directive in the PR body such as `Closes #123`.
+- Pull requests MUST summarize the change, testing performed, and any rollout or migration impact.
+- Direct commits to `main` are prohibited. All merges flow through reviewed pull requests after required checks pass.
+- Squash merge is the default merge strategy unless repository governance explicitly requires another merge mode.
+- The final merge action MUST preserve the issue-closing directive so GitHub automatically closes the linked issue when the PR lands.
+
 ## wasmCloud + Wasmtime Integration Model
 - Services are designed for wasmCloud deployment with Wasmtime-compatible modules.
 - Nomad and surrounding infrastructure deploy lattice hosts and support infrastructure, not native per-service binaries.
@@ -107,3 +130,8 @@ cargo test --workspace --all-targets
 - Agents may propose changes outside their domain but may not execute boundary-crossing mutations without policy/workflow authorization.
 - When requirements conflict, agents prioritize contract correctness, policy compliance, and test pass criteria in that order.
 - Agents MUST NOT introduce Codex, OpenAI, ChatGPT, or similar branding into repository artifacts unless explicitly required for a documented third-party reference or legal attribution.
+- Agents performing repository delivery work MUST follow the GitHub workflow protocol above:
+  - create or refine the issue first when the task is intended for GitHub tracking,
+  - use an issue-derived branch name,
+  - open a PR with `Closes #<issue-id>` in the body,
+  - never bypass review or protected-branch policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,41 @@
 # Contributing
 
-## Workflow
+## GitHub Workflow Protocol
 
-All material changes are issue-driven.
+All material changes are issue-driven and must follow the same GitHub workflow:
 
-1. Open or refine a GitHub issue using the repository issue forms.
-2. Move the issue onto the organization Project in the correct `Status` column.
-3. Create a short-lived branch named `feature/<issue-id>-description`, `fix/<issue-id>-description`, `infra/<issue-id>-description`, `docs/<issue-id>-description`, `refactor/<issue-id>-description`, or `research/<issue-id>-description`.
-4. Keep the change set small enough to review and merge quickly.
-5. Open a pull request that links the issue, describes the technical changes, and includes a testing strategy.
+1. Create or refine a same-repository GitHub issue before writing code.
+2. Ensure the issue captures:
+   - the change, defect, or enhancement being proposed,
+   - enough background and scope for another contributor to understand the request,
+   - explicit acceptance criteria,
+   - supporting technical notes, constraints, and related links where needed.
+3. Move the issue onto the organization Project in the correct `Status` column.
+4. Create a dedicated short-lived branch from the latest `main`.
+5. Name the branch with the issue identifier using:
+   - `feature/<issue-id>-description`
+   - `fix/<issue-id>-description`
+   - `infra/<issue-id>-description`
+   - `docs/<issue-id>-description`
+   - `refactor/<issue-id>-description`
+   - `research/<issue-id>-description`
+6. Implement the change on that issue branch and keep the change set small enough to review and merge quickly.
+7. Open a pull request targeting `main` that:
+   - references the originating issue,
+   - explains the technical change,
+   - documents the testing strategy,
+   - includes a closing directive such as `Closes #<issue-id>`.
+8. Merge only after review and required checks pass so GitHub automatically closes the linked issue.
+
+Example commands:
+
+```bash
+gh issue create
+git switch main
+git pull --ff-only
+git switch -c fix/123-runtime-error-contract
+gh pr create --fill
+```
 
 ## Pull Request Requirements
 
@@ -19,6 +46,7 @@ All material changes are issue-driven.
 - Required checks must pass before merge.
 - At least one reviewer approval is required before merge.
 - Squash merge is the default merge strategy.
+- Keep the `Closes #<issue-id>` directive in the PR body through merge so the issue closes automatically.
 
 ## Labels and Milestones
 

--- a/DEVELOPMENT_MODEL.md
+++ b/DEVELOPMENT_MODEL.md
@@ -11,6 +11,7 @@ This repository uses a GitHub-native Scrumban workflow built around issues, pull
 3. Every merge flows through a reviewed pull request.
 4. Required checks must pass before merge.
 5. Work stays visible on the organization Project board.
+6. Every pull request must retain a GitHub issue closing directive so merge closes the originating issue automatically.
 
 ## Flow
 
@@ -44,6 +45,13 @@ Every issue should capture:
 - Technical Notes
 - Related Issues
 
+Issue creation protocol:
+
+1. Create the issue before starting implementation.
+2. Confirm the issue title is specific enough to support branch and PR naming.
+3. Record enough context that another contributor can execute the change without private side-channel knowledge.
+4. Keep acceptance criteria concrete and testable.
+
 ## Branching and Commits
 
 Short-lived trunk-based branches are required:
@@ -54,6 +62,13 @@ Short-lived trunk-based branches are required:
 - `docs/<issue-id>-description`
 - `refactor/<issue-id>-description`
 - `research/<issue-id>-description`
+
+Branch protocol:
+
+1. Branch from the latest `main`.
+2. Include the GitHub issue identifier in the branch name.
+3. Use one primary issue per branch.
+4. Delete the branch after merge.
 
 PR titles and squash-merge commit messages must use conventional commits:
 
@@ -74,6 +89,7 @@ Every PR must include:
 - technical changes
 - testing strategy
 - deployment impact
+- a closing directive in the PR body such as `Closes #123`
 - repository-native language with no leaked Codex, OpenAI, ChatGPT, or other assistant/vendor branding unless required for an external reference or legal attribution
 
 Merge policy:
@@ -84,6 +100,7 @@ Merge policy:
 - dismiss stale approvals when new commits are pushed
 - code owner review: required
 - auto-merge: enabled as the fallback path when merge queue is unavailable
+- merging the PR closes the linked issue through the PR closing directive
 
 ## CI/CD Baseline
 

--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ Origin is a Rust-first, contract-driven platform organized around explicit modul
 
 Origin uses a GitHub-native Scrumban model.
 
-1. Start with a GitHub issue.
-2. Work on a short-lived branch named `feature/<issue-id>-description`, `fix/<issue-id>-description`, or the matching approved prefix from [DEVELOPMENT_MODEL.md](/Users/justinshort/short%20origin/DEVELOPMENT_MODEL.md).
-3. Open a pull request with a conventional title such as `feat(auth): add oauth provider`.
-4. Merge to `main` through squash merge after review and required checks pass.
+1. Start with a same-repository GitHub issue that defines context, scope, and acceptance criteria.
+2. Work on a short-lived issue branch named `<type>/<issue-id>-description` using an approved prefix from [DEVELOPMENT_MODEL.md](/Users/justinshort/short%20origin/DEVELOPMENT_MODEL.md).
+3. Open a pull request with a conventional title and a PR body that includes `Closes #<issue-id>`.
+4. Merge to `main` only after review and required checks pass so the linked issue closes automatically.
 
 Primary contributor docs:
 
 - [ARCHITECTURE.md](/Users/justinshort/short%20origin/ARCHITECTURE.md)
 - [CONTRIBUTING.md](/Users/justinshort/short%20origin/CONTRIBUTING.md)
 - [DEVELOPMENT_MODEL.md](/Users/justinshort/short%20origin/DEVELOPMENT_MODEL.md)
+- [GitHub governance rollout](/Users/justinshort/short%20origin/docs/process/github-governance-rollout.md)
 - [Local wasmCloud development](/Users/justinshort/short%20origin/docs/process/wasmcloud-local-dev.md)
 - [SECURITY.md](/Users/justinshort/short%20origin/SECURITY.md)
 

--- a/docs/process/github-governance-rollout.md
+++ b/docs/process/github-governance-rollout.md
@@ -8,6 +8,17 @@ This repository is the pilot adopter for the `shortorigin` GitHub-native Scrumba
 - Issue forms: [`.github/ISSUE_TEMPLATE`](/Users/justinshort/short%20origin/.github/ISSUE_TEMPLATE)
 - PR template: [`.github/PULL_REQUEST_TEMPLATE.md`](/Users/justinshort/short%20origin/.github/PULL_REQUEST_TEMPLATE.md)
 - Development policy: [DEVELOPMENT_MODEL.md](/Users/justinshort/short%20origin/DEVELOPMENT_MODEL.md)
+- Contributor workflow: [CONTRIBUTING.md](/Users/justinshort/short%20origin/CONTRIBUTING.md)
+
+## Required GitHub Workflow Protocol
+
+Every material repository change follows the same GitHub lifecycle:
+
+1. Create a GitHub issue with context, scope, and acceptance criteria.
+2. Create a dedicated issue branch from `main` named `<type>/<issue-id>-<summary>`.
+3. Implement the change on that branch.
+4. Open a pull request that references the issue and includes `Closes #<issue-id>` in the body.
+5. Merge only after review and required checks pass so GitHub closes the linked issue automatically.
 
 ## Bootstrap Commands
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -50,6 +50,35 @@ The shell supports two runtime targets with a shared Rust composition core:
 
 `desktop_runtime` is the common execution core for both targets. It keeps reducer-owned state, effect generation, compositor behavior, and shell composition in one Rust runtime while host capabilities vary by adapter selection.
 
+## Observability and Errors
+`ui/` now standardizes on typed host/runtime errors plus structured tracing-based diagnostics.
+
+- `shared/error-model` provides shared error classification metadata such as category and visibility.
+- `shared/telemetry` provides stable runtime-target and environment-profile types used by UI logs.
+- `platform_host` owns the canonical UI host error contract through `HostError` and `HostResult<T>`.
+- `desktop_runtime` owns shared runtime logging metadata helpers and emits structured events through `tracing`.
+- `site` initializes wasm logging, while `desktop_tauri` initializes the native JSON subscriber.
+
+Required log fields:
+- `timestamp`
+- `level`
+- `target`
+- `event`
+- `operation`
+- `component`
+- `runtime_target`
+- `environment`
+
+Optional fields should be additive and stable, for example `window_id`, `app_id`, `host_strategy`, `error_category`, and `error_code`.
+
+Development builds may emit richer diagnostics. Production defaults should stay concise, favor `warn` and `error` in wasm/browser flows, and avoid leaking internal details to end users.
+
+Prohibited patterns:
+- `Result<_, String>` on public UI host boundaries when a typed `HostError` is appropriate
+- ad hoc free-form runtime diagnostics when structured `tracing` events can be emitted instead
+- logging secrets, raw credentials, uncontrolled payload dumps, or sensitive absolute paths
+- non-test `unwrap`/`expect` on recoverable runtime and host paths
+
 ## Development Workflow
 Use the browser/WASM preview for fast shell iteration and parity checks. Use the Tauri path to validate desktop-only integrations and packaged behavior. Keep all new UI integration behind typed contracts and place presentation-specific models only in `ui/`.
 


### PR DESCRIPTION
## Summary
- codify the required issue -> branch -> PR workflow across contributor-facing governance docs
- require issue-derived branch names and PR closing directives in repository guidance
- link the governance rollout doc to the contributor workflow entrypoints

## Testing
- not run (documentation-only change)

## Rollout / Migration Impact
- no runtime impact
- contributors should follow the documented workflow for new material changes

Closes #72
