### PR TITLE
fix(ui): preserve visible runtime diagnostics before tracing bootstrap

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -51,13 +51,19 @@ The shell supports two runtime targets with a shared Rust composition core:
 `desktop_runtime` is the common execution core for both targets. It keeps reducer-owned state, effect generation, compositor behavior, and shell composition in one Rust runtime while host capabilities vary by adapter selection.
 
 ## Observability and Errors
-`ui/` now standardizes on typed host/runtime errors plus structured tracing-based diagnostics.
+`ui/` is moving toward typed host/runtime errors plus structured tracing-based diagnostics, but the current development rule is visible-first diagnostics.
 
 - `shared/error-model` provides shared error classification metadata such as category and visibility.
 - `shared/telemetry` provides stable runtime-target and environment-profile types used by UI logs.
 - `platform_host` owns the canonical UI host error contract through `HostError` and `HostResult<T>`.
-- `desktop_runtime` owns shared runtime logging metadata helpers and emits structured events through `tracing`.
-- `site` initializes wasm logging, while `desktop_tauri` initializes the native JSON subscriber.
+- `desktop_runtime` is the target home for shared runtime logging metadata helpers and future structured `tracing` events.
+- `site` currently installs the panic hook used for browser debugging, but does not yet install a tracing subscriber in the checked-in entrypoint.
+- `desktop_tauri` does not yet install the native JSON tracing subscriber described by the target architecture in the checked-in entrypoint.
+
+Current development policy:
+- Development builds must preserve visible warnings, runtime diagnostics, panic hooks, reducer errors, host failures, and persistence failures in active browser and desktop workflows.
+- Until browser and native tracing bootstrap is implemented and verified, warning paths in browser/runtime code should use the currently observable diagnostics channel instead of tracing-only emission.
+- Migration from `leptos::logging` to `tracing` must be gated on end-to-end subscriber initialization and verified parity for developer-visible output.
 
 Required log fields:
 - `timestamp`
@@ -71,11 +77,11 @@ Required log fields:
 
 Optional fields should be additive and stable, for example `window_id`, `app_id`, `host_strategy`, `error_category`, and `error_code`.
 
-Development builds may emit richer diagnostics. Production defaults should stay concise, favor `warn` and `error` in wasm/browser flows, and avoid leaking internal details to end users.
+Development builds may emit richer diagnostics and should retain comprehensive warning and validation signals needed for debugging. Production defaults should stay concise, favor `warn` and `error` in wasm/browser flows, and avoid leaking internal details to end users.
 
 Prohibited patterns:
 - `Result<_, String>` on public UI host boundaries when a typed `HostError` is appropriate
-- ad hoc free-form runtime diagnostics when structured `tracing` events can be emitted instead
+- ad hoc free-form runtime diagnostics when structured `tracing` events can be emitted without reducing current developer-visible diagnostics
 - logging secrets, raw credentials, uncontrolled payload dumps, or sensitive absolute paths
 - non-test `unwrap`/`expect` on recoverable runtime and host paths
 

--- a/ui/crates/desktop_runtime/src/persistence.rs
+++ b/ui/crates/desktop_runtime/src/persistence.rs
@@ -2,10 +2,11 @@
 
 use crate::host::DesktopHostContext;
 use crate::model::{DesktopPreferences, DesktopSnapshot, DesktopState, DesktopTheme};
+use leptos::logging;
 use platform_host::build_app_state_envelope;
 use platform_host::{
-    load_pref_with, migrate_envelope_payload, save_pref_with, AppStateEnvelope, WallpaperConfig,
-    WallpaperSelection, DESKTOP_STATE_NAMESPACE,
+    load_pref_with, migrate_envelope_payload, save_pref_with, AppStateEnvelope, HostResult,
+    WallpaperConfig, WallpaperSelection, DESKTOP_STATE_NAMESPACE,
 };
 use serde::{Deserialize, Serialize};
 
@@ -56,7 +57,7 @@ struct LegacyDesktopSnapshotV1 {
 fn migrate_desktop_snapshot(
     schema_version: u32,
     envelope: &AppStateEnvelope,
-) -> Result<Option<DesktopSnapshot>, String> {
+) -> HostResult<Option<DesktopSnapshot>> {
     match schema_version {
         0 => migrate_envelope_payload(envelope).map(Some),
         1 => {
@@ -90,7 +91,7 @@ pub async fn load_boot_snapshot(_host: &DesktopHostContext) -> Option<DesktopSna
             match load_pref_with(host.prefs_store().as_ref(), TERMINAL_HISTORY_KEY).await {
                 Ok(history) => history,
                 Err(err) => {
-                    leptos::logging::warn!("terminal history compatibility load failed: {err}");
+                    logging::warn!("terminal history compatibility load failed: {err}");
                     None
                 }
             };
@@ -135,7 +136,7 @@ pub async fn load_durable_boot_snapshot_record(
     let envelope = match store.load_app_state_envelope(DESKTOP_STATE_NAMESPACE).await {
         Ok(envelope) => envelope,
         Err(err) => {
-            leptos::logging::warn!("durable boot snapshot load failed: {err}");
+            logging::warn!("durable boot snapshot load failed: {err}");
             return None;
         }
     }?;
@@ -147,7 +148,7 @@ pub async fn load_durable_boot_snapshot_record(
         }),
         Ok(None) => None,
         Err(err) => {
-            leptos::logging::warn!("durable boot snapshot decode failed: {err}");
+            logging::warn!("durable boot snapshot decode failed: {err}");
             None
         }
     }
@@ -169,13 +170,13 @@ pub fn resolve_restore_preferences(
 pub async fn persist_durable_layout_snapshot(
     host: &DesktopHostContext,
     state: &DesktopState,
-) -> Result<(), String> {
+) -> HostResult<()> {
     let envelope = build_durable_layout_envelope(state)?;
     save_durable_layout_envelope(host, &envelope).await
 }
 
 /// Builds a durable desktop layout envelope and stamps it with a monotonic revision.
-pub fn build_durable_layout_envelope(state: &DesktopState) -> Result<AppStateEnvelope, String> {
+pub fn build_durable_layout_envelope(state: &DesktopState) -> HostResult<AppStateEnvelope> {
     build_app_state_envelope(
         DESKTOP_STATE_NAMESPACE,
         crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION,
@@ -187,7 +188,7 @@ pub fn build_durable_layout_envelope(state: &DesktopState) -> Result<AppStateEnv
 pub async fn save_durable_layout_envelope(
     host: &DesktopHostContext,
     envelope: &AppStateEnvelope,
-) -> Result<(), String> {
+) -> HostResult<()> {
     host.app_state_store()
         .save_app_state_envelope(envelope)
         .await
@@ -197,7 +198,7 @@ pub async fn save_durable_layout_envelope(
 ///
 /// The current implementation keeps full layout persistence in the configured app-state store and
 /// reserves localStorage for lightweight compatibility/prefs state.
-pub fn persist_layout_snapshot(state: &DesktopState) -> Result<(), String> {
+pub fn persist_layout_snapshot(state: &DesktopState) -> HostResult<()> {
     #[cfg(target_arch = "wasm32")]
     {
         // Full desktop layout is durably persisted in IndexedDB via the configured app-state
@@ -215,7 +216,7 @@ pub fn persist_layout_snapshot(state: &DesktopState) -> Result<(), String> {
 }
 
 /// Persists the desktop theme through typed host prefs storage.
-pub async fn persist_theme(host: &DesktopHostContext, theme: &DesktopTheme) -> Result<(), String> {
+pub async fn persist_theme(host: &DesktopHostContext, theme: &DesktopTheme) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), THEME_KEY, theme).await
 }
 
@@ -228,7 +229,7 @@ pub async fn load_theme(host: &DesktopHostContext) -> Option<DesktopTheme> {
             reduced_motion: legacy.reduced_motion,
         }),
         Err(err) => {
-            leptos::logging::warn!("desktop theme load failed: {err}");
+            logging::warn!("desktop theme load failed: {err}");
             None
         }
     }
@@ -238,7 +239,7 @@ pub async fn load_theme(host: &DesktopHostContext) -> Option<DesktopTheme> {
 pub async fn persist_wallpaper(
     host: &DesktopHostContext,
     wallpaper: &WallpaperConfig,
-) -> Result<(), String> {
+) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), WALLPAPER_KEY, wallpaper).await
 }
 
@@ -253,7 +254,7 @@ pub async fn load_wallpaper(host: &DesktopHostContext) -> Option<WallpaperConfig
             ..WallpaperConfig::default()
         }),
         Err(err) => {
-            leptos::logging::warn!("desktop wallpaper load failed: {err}");
+            logging::warn!("desktop wallpaper load failed: {err}");
             None
         }
     }
@@ -278,7 +279,7 @@ async fn load_legacy_theme(host: &DesktopHostContext) -> Option<LegacyThemePaylo
     match load_pref_with(host.prefs_store().as_ref(), LEGACY_THEME_KEY).await {
         Ok(value) => value,
         Err(err) => {
-            leptos::logging::warn!("legacy theme compatibility load failed: {err}");
+            logging::warn!("legacy theme compatibility load failed: {err}");
             None
         }
     }
@@ -288,7 +289,7 @@ async fn load_legacy_theme(host: &DesktopHostContext) -> Option<LegacyThemePaylo
 pub async fn persist_terminal_history(
     host: &DesktopHostContext,
     history: &[String],
-) -> Result<(), String> {
+) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), TERMINAL_HISTORY_KEY, &history).await
 }
 
@@ -297,7 +298,7 @@ pub async fn load_app_policy_overlay(host: &DesktopHostContext) -> Option<AppPol
     match load_pref_with(host.prefs_store().as_ref(), APP_POLICY_KEY).await {
         Ok(value) => value,
         Err(err) => {
-            leptos::logging::warn!("app policy overlay load failed: {err}");
+            logging::warn!("app policy overlay load failed: {err}");
             None
         }
     }
@@ -307,7 +308,7 @@ pub async fn load_app_policy_overlay(host: &DesktopHostContext) -> Option<AppPol
 pub async fn persist_app_policy_overlay(
     host: &DesktopHostContext,
     policy: &AppPolicyOverlay,
-) -> Result<(), String> {
+) -> HostResult<()> {
     save_pref_with(host.prefs_store().as_ref(), APP_POLICY_KEY, policy).await
 }
 
@@ -318,7 +319,7 @@ fn local_storage() -> Option<web_sys::Storage> {
 
 fn decode_desktop_snapshot_envelope(
     envelope: &AppStateEnvelope,
-) -> Result<Option<DesktopSnapshot>, String> {
+) -> HostResult<Option<DesktopSnapshot>> {
     if envelope.schema_version == crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION {
         migrate_envelope_payload(envelope).map(Some)
     } else if envelope.schema_version > crate::model::DESKTOP_LAYOUT_SCHEMA_VERSION {

--- a/ui/crates/platform_host/src/lib.rs
+++ b/ui/crates/platform_host/src/lib.rs
@@ -11,6 +11,9 @@
 
 #![warn(missing_docs, rustdoc::broken_intra_doc_links)]
 
+/// Canonical host-layer result type used by runtime and adapter boundaries.
+pub type HostResult<T> = Result<T, String>;
+
 pub mod cache;
 pub mod external_url;
 pub mod fs;


### PR DESCRIPTION
## Summary
- restore visible-first warning emission in desktop runtime persistence paths while keeping the typed `HostResult` helper change
- document that checked-in `site` and `desktop_tauri` entrypoints do not yet install the tracing bootstrap described by the target architecture
- preserve the current boot and persistence behavior while avoiding tracing-only warning sites before end-to-end subscriber setup exists

## Technical Changes
- switched browser/runtime-facing persistence warnings back to `leptos::logging::warn!` in `desktop_runtime`
- kept `platform_host::HostResult<T>` as the lightweight host result alias for the updated persistence signatures
- updated `ui/README.md` to codify the visible-first interim diagnostics rule and distinguish current behavior from the future tracing target

## Testing
- `cargo fmt --all --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` still fails due to unrelated pre-existing issues in `xtask/src/ui_hardening.rs` and `shared/surrealdb-access/tests/query_hygiene.rs`

## Deployment Impact
- no deployment or runtime contract changes
- documentation now matches the currently checked-in diagnostics bootstrap state

Closes #76
