### PR TITLE
docs(github): add pr conflict reduction playbook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,13 @@
 
 Closes #
 
+## Workflow Checklist
+
+- [ ] This branch is based on the current target branch (`origin/main` for normal PRs, the parent branch for stacked PRs).
+- [ ] If this PR is stacked, the PR base points to the parent branch until that parent work merges.
+- [ ] If this PR touches `ui/crates/desktop_runtime`, `ui/crates/system_ui`, or `ui/crates/site/src/generated`, I rebased immediately before requesting merge.
+- [ ] If this PR updates generated assets or token outputs, I regenerated them after the last rebase.
+
 ## Technical Changes
 
 ## Testing Strategy

--- a/.github/governance.toml
+++ b/.github/governance.toml
@@ -9,11 +9,16 @@ governance_repository_description = "Canonical Origin GitHub governance, issue f
 default_branch = "main"
 branch_name_pattern = "^(feature|fix|infra|docs|refactor|research)/[0-9]+-[a-z0-9-]+$"
 pr_title_pattern = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|test)\\([a-z0-9][a-z0-9_-]*\\): [a-z0-9].+$"
+# `xtask github sync repo` applies these checks with strict status enforcement so PR heads
+# must be current with the target branch before merge.
 required_status_checks = ["Governance / validate", "CI / pr-gate", "Security / security-gate"]
+# `main` requires one approval and code owner review. Stacked PRs should target their
+# parent branch until the base PR merges instead of pointing multiple layers at `main`.
 required_approving_review_count = 1
 dismiss_stale_reviews_on_push = true
 require_code_owner_review = true
 required_review_thread_resolution = true
+# Keep one merge path on `main`; merge queue is enabled separately in GitHub UI.
 allow_auto_merge = true
 allow_squash_merge = true
 allow_merge_commit = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,29 +11,31 @@ All material changes are issue-driven and must follow the same GitHub workflow:
    - explicit acceptance criteria,
    - supporting technical notes, constraints, and related links where needed.
 3. Move the issue onto the organization Project in the correct `Status` column.
-4. Create a dedicated short-lived branch from the latest `main`.
-5. Name the branch with the issue identifier using:
+4. Fetch the current remote branch tips before creating a working branch: `git fetch origin`.
+5. Create a dedicated short-lived branch from `origin/main`, not from a stale local `main`.
+6. Name the branch with the issue identifier using:
    - `feature/<issue-id>-description`
    - `fix/<issue-id>-description`
    - `infra/<issue-id>-description`
    - `docs/<issue-id>-description`
    - `refactor/<issue-id>-description`
    - `research/<issue-id>-description`
-6. Implement the change on that issue branch and keep the change set small enough to review and merge quickly.
-7. Open a pull request targeting `main` that:
+7. Implement the change on that issue branch and keep the change set small enough to review and merge quickly.
+8. If the work is stacked, create the child branch from its parent branch and open the child PR against the parent branch until the base PR lands.
+9. Rebase on the current target branch before requesting merge, and rebase again if the target branch moves while the PR is open.
+10. Open a pull request targeting `main` or the parent branch in a stack that:
    - references the originating issue,
    - explains the technical change,
    - documents the testing strategy,
    - includes a closing directive such as `Closes #<issue-id>`.
-8. Merge only after review and required checks pass so GitHub automatically closes the linked issue.
+11. Merge only after review and required checks pass so GitHub automatically closes the linked issue.
 
 Example commands:
 
 ```bash
 gh issue create
-git switch main
-git pull --ff-only
-git switch -c fix/123-runtime-error-contract
+git fetch origin
+git switch -c fix/123-runtime-error-contract origin/main
 gh pr create --fill
 ```
 
@@ -47,6 +49,10 @@ gh pr create --fill
 - At least one reviewer approval is required before merge.
 - Squash merge is the default merge strategy.
 - Keep the `Closes #<issue-id>` directive in the PR body through merge so the issue closes automatically.
+- If the PR is stacked, target the parent branch until the base PR merges.
+- If the PR touches `ui/crates/desktop_runtime`, `ui/crates/system_ui`, or `ui/crates/site/src/generated`, rebase on the current target branch immediately before requesting merge.
+- Regenerate derived assets after the last rebase and before review whenever the PR changes token, shell, or generated CSS inputs.
+- Do not mix unrelated shell refactors, generated asset churn, and behavioral fixes into one PR when they can be reviewed separately.
 
 ## Labels and Milestones
 

--- a/docs/process/github-governance-rollout.md
+++ b/docs/process/github-governance-rollout.md
@@ -9,16 +9,19 @@ This repository is the pilot adopter for the `shortorigin` GitHub-native Scrumba
 - PR template: [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
 - Development policy: [`DEVELOPMENT_MODEL.md`](../../DEVELOPMENT_MODEL.md)
 - Contributor workflow: [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+- Conflict-reduction playbook: [`pr-conflict-reduction-playbook.md`](pr-conflict-reduction-playbook.md)
 
 ## Required GitHub Workflow Protocol
 
 Every material repository change follows the same GitHub lifecycle:
 
 1. Create a GitHub issue with context, scope, and acceptance criteria.
-2. Create a dedicated issue branch from `main` named `<type>/<issue-id>-<summary>`.
-3. Implement the change on that branch.
-4. Open a pull request that references the issue and includes `Closes #<issue-id>` in the body.
-5. Merge only after review and required checks pass so GitHub closes the linked issue automatically.
+2. Run `git fetch origin` before creating the working branch.
+3. Create a dedicated issue branch from `origin/main` named `<type>/<issue-id>-<summary>`.
+4. If the work is stacked, branch from the parent branch and target the child PR to that parent branch until it lands.
+5. Rebase on the current target branch before requesting merge.
+6. Open a pull request that references the issue and includes `Closes #<issue-id>` in the body.
+7. Merge only after review and required checks pass so GitHub closes the linked issue automatically.
 
 ## Bootstrap Commands
 
@@ -61,7 +64,8 @@ The repo sync covers:
 - milestones
 - repository rulesets for `main` protection and branch naming
 - required code owner review on `main`
-- auto-merge enablement for protected-branch fallback
+- strict required status checks on `main`, which force PR heads to be current with the base branch before merge
+- auto-merge enablement for protected-branch fallback when merge queue is unavailable
 
 ## Manual GitHub UI Steps
 
@@ -71,10 +75,18 @@ The GitHub CLI currently does not cover all project-view and workflow configurat
 2. Create saved milestone views for each standard milestone.
 3. Enable built-in Project workflows so new issues land in `Backlog`.
 4. Configure status transitions so linked pull requests move issues through `PR Open`, `Review`, and `Done`.
-5. Enable merge queue for `main` if the plan supports it.
+5. Enable merge queue for `main`.
 6. Create GitHub environments `dev`, `stage`, and `production`.
 7. Configure `production` to require `@shortorigin/core-maintainers` approval and disable self-approval.
 8. Enable secret scanning, push protection, and private vulnerability reporting.
+
+After applying or changing governance, run:
+
+```bash
+cargo xtask github audit-process
+```
+
+Use the audit output to confirm that the live ruleset still matches `.github/governance.toml`, especially for required approvals, merge method restrictions, and status check enforcement.
 
 ## Required Checks
 
@@ -83,6 +95,23 @@ Configure the `main` ruleset to require these check names:
 - `Governance / validate`
 - `CI / pr-gate`
 - `Security / security-gate`
+
+## Review And Merge Expectations
+
+The checked-in governance source-of-truth for `main` expects:
+
+- one approving review,
+- code owner review,
+- stale approvals dismissed on push,
+- squash merge only,
+- delete branch on merge.
+
+Contributor workflow should match those protections:
+
+- branch from fresh `origin/main`,
+- use parent-targeted stacked PRs instead of opening stacked branches directly against `main`,
+- rebase before merge when `main` has moved,
+- regenerate derived outputs after rebasing if the PR changes shell or token inputs.
 
 ## Environment Secrets and Vars
 

--- a/docs/process/pr-conflict-reduction-playbook.md
+++ b/docs/process/pr-conflict-reduction-playbook.md
@@ -1,0 +1,138 @@
+# PR Conflict Reduction Playbook
+
+This repository has recurring pull request merge conflicts because multiple short-lived branches are still converging on the same small set of `ui/` shell files while `main` is moving quickly. This document records the concrete failure pattern observed on March 8, 2026 and establishes the branch, rebase, and PR integration rules that reduce those conflicts.
+
+## Observed Conflict Conditions
+
+The current conflict pattern is not theoretical. It is tied to specific conditions already present in this repository:
+
+- PR [#85](https://github.com/shortorigin/origin/pull/85) and PR [#86](https://github.com/shortorigin/origin/pull/86) were both opened on March 8, 2026 at `16:38:57Z` and both targeted `main`.
+- PR [#82](https://github.com/shortorigin/origin/pull/82) merged into `main` on March 8, 2026 at `16:41:16Z`, less than three minutes later.
+- PR `#85` was stacked on `#86`, but the child PR still targeted `main` instead of the parent branch.
+- The local `origin/main` reference used during branch preparation lagged the actual remote `main` tip (`e14cd0f` locally versus `9a63e00` on GitHub after fetch).
+- The affected PRs all touched the same conflict hot spots:
+  - `ui/crates/desktop_runtime/src/components*`
+  - `ui/crates/system_ui/*`
+  - `ui/crates/site/src/generated/*`
+
+Recent merged pull requests show repeated overlap in the same subsystem. The recurring conflict surface is the desktop shell/runtime boundary, especially shell components, generated CSS/tokens, and the system UI token/build pipeline.
+
+## Root Causes
+
+### 1. Stale branch bases
+
+Branches were prepared from a local view of `main` that was already behind GitHub. That makes conflicts likely before review even starts.
+
+### 2. Stacked PRs opened directly against `main`
+
+This repository defaults to squash merge. When a child branch includes the parent branch's commits and still targets `main`, the child PR carries unrelated base work and becomes fragile as soon as the parent or another overlapping PR lands.
+
+### 3. Parallel work in high-churn shell files
+
+The same `ui/` shell/runtime files are being edited by multiple refactors and fixes in close succession. Even well-scoped branches conflict when they change the same layout, token, and generated output surfaces at the same time.
+
+### 4. Mixed source changes and generated outputs
+
+Shell PRs frequently include both hand-authored source changes and regenerated outputs such as `ui/crates/site/src/generated/tailwind.css` and `ui/crates/site/src/generated/tokens.css`. Those generated files amplify conflicts because they are large, derived from shared inputs, and easy to invalidate after a rebase.
+
+### 5. Governance drift between source-of-truth and live settings
+
+The checked-in governance config requires one approval, code owner review, squash merge only, and strict status checks. The live repository ruleset was observed in a weaker state, which means contributors can follow a looser workflow than the repo intends unless governance is re-synced and audited.
+
+## Required Branch Lifecycle
+
+Use this lifecycle for every material change:
+
+```bash
+gh issue create
+git fetch origin
+git switch -c <type>/<issue-id>-<summary> origin/main
+```
+
+Rules:
+
+1. Always fetch before creating the branch.
+2. Create the branch from `origin/main`, not from a stale local `main`.
+3. Keep the branch focused on one primary issue.
+4. Rebase on the current target branch before requesting merge.
+5. If `main` moves while the PR is open, rebase again before merge.
+
+For conflict hot spots, rebasing before merge is mandatory:
+
+- `ui/crates/desktop_runtime`
+- `ui/crates/system_ui`
+- `ui/crates/site/src/generated`
+
+## Stacked PR Rules
+
+Stacked work is allowed, but only with explicit base-branch discipline:
+
+1. Create the child branch from the parent branch.
+2. Open the child PR against the parent branch, not against `main`.
+3. After the parent merges, rebase the child onto fresh `origin/main`.
+4. Retarget the child PR to `main` only after the rebase is complete.
+5. Do not ask reviewers to review a child PR that still contains parent-only commits unrelated to the child change.
+
+Under squash merge, this rule is non-optional. The child branch cannot rely on parent commit hashes surviving merge.
+
+## High-Churn UI Shell Sequencing
+
+When work touches the shell/runtime conflict hot spots:
+
+1. Avoid running multiple parallel PRs that all modify shell layout, taskbar composition, token generation, or generated CSS outputs.
+2. Split refactors from behavior fixes when practical.
+3. Do not combine wallpaper, taskbar, shell layout, and token regeneration into one PR unless they are inseparable.
+4. Regenerate derived assets only after rebasing onto the current target branch.
+5. Treat `ui/crates/site/src/generated/*` as derived artifacts that must be refreshed after every rebase that changes shell or token inputs.
+
+## Conflict Resolution Playbook
+
+When a PR becomes stale or conflicting:
+
+```bash
+git fetch origin
+git switch <branch>
+git rebase origin/main
+```
+
+If the PR is stacked:
+
+```bash
+git fetch origin
+git switch <child-branch>
+git rebase <parent-branch-or-origin/main>
+```
+
+After the rebase:
+
+1. Resolve conflicts in source files first.
+2. Regenerate derived assets from the rebased sources.
+3. Re-run validation.
+4. Force-push the rebased branch with lease protection.
+5. If the PR was stacked, retarget it only after the branch content matches the intended review scope.
+
+Recommended validation:
+
+```bash
+cargo xtask github audit-process
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets
+```
+
+## Governance And Review Expectations
+
+The checked-in governance model for `main` expects:
+
+- one approving review,
+- code owner review,
+- stale approvals dismissed on push,
+- strict required status checks,
+- squash merge only,
+- delete branch on merge.
+
+Operational follow-through:
+
+1. Re-sync repository governance after changing `.github/governance.toml`.
+2. Run `cargo xtask github audit-process` regularly to detect drift.
+3. Enable merge queue for `main` in GitHub so conflicting or stale PRs are rebased through a single protected integration path.


### PR DESCRIPTION
## Summary
- add a repo-specific playbook for recurring PR merge conflicts using the current `ui/` shell incidents as evidence
- tighten contributor and governance rollout guidance around fresh branch bases, rebasing, stacked PR targeting, and generated asset regeneration
- extend the PR template checklist so authors confirm branch freshness and stacked PR discipline before merge

## Linked Issue
Closes #87

## Technical Changes
- add `docs/process/pr-conflict-reduction-playbook.md` with root causes, conflict hot spots, and a rebasing/retargeting playbook
- update `CONTRIBUTING.md` to require `git fetch origin`, branching from `origin/main`, and parent-targeted stacked PRs
- update `docs/process/github-governance-rollout.md` and `.github/governance.toml` to align the documented workflow with the repo governance source-of-truth
- add a workflow checklist to `.github/PULL_REQUEST_TEMPLATE.md` for fresh bases and regenerated derived assets

## Testing Strategy
- `cargo xtask github audit-process`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets`

## Deployment Impact
- repository workflow and governance documentation only
- no runtime or product behavior changes