### PR TITLE
feature: add standalone plugin manifest validation

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Audit architecture boundaries
         run: cargo xtask architecture audit-boundaries
 
+      - name: Validate governed plugin manifests
+        run: cargo xtask plugin validate-manifests
+
       - name: Audit documented process against automation
         run: cargo xtask github audit-process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,7 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-targets
 cargo xtask architecture audit-boundaries
+cargo xtask plugin validate-manifests
 cargo xtask github audit-process
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy 0.8.40",
 ]
@@ -153,8 +154,58 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "vte",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1014,7 +1065,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1123,6 +1174,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1236,12 @@ name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1188,7 +1285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
  "convert_case 0.6.0",
- "nom",
+ "nom 7.1.3",
  "pathdiff",
  "serde",
  "toml 0.8.23",
@@ -2244,6 +2341,17 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
@@ -2367,6 +2475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3485,6 +3603,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom 8.0.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,6 +3743,36 @@ checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0f4bea31643be4c6a678e9aa4ae44f0db9e5609d5ca9dc9083d06eb3e9a27a"
+dependencies = [
+ "ahash 0.8.12",
+ "anyhow",
+ "base64 0.22.1",
+ "bytecount",
+ "clap",
+ "fancy-regex 0.13.0",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4490,6 +4653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4553,7 +4725,7 @@ version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2941b86e4bf40ef4fee71d11797553b2652d2049cf882a27e976fe4ce6d391"
 dependencies = [
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "log",
  "nu-experimental",
  "nu-glob",
@@ -4614,7 +4786,7 @@ dependencies = [
  "chrono-humanize",
  "dirs",
  "dirs-sys",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "heck 0.5.0",
  "indexmap 2.13.0",
  "log",
@@ -4666,7 +4838,7 @@ version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7629c3d80844f5106509c230da1ff388bc43559832f4206e1bb98d3562a8ca0"
 dependencies = [
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
@@ -4683,7 +4855,7 @@ checksum = "17feaeb5f4e8d44b8dabd3abf4dc226dc711d2c18683dc68f5b39a2884c693d4"
 dependencies = [
  "byteyarn",
  "crossterm_winapi",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "lean_string",
  "log",
  "lscolors",
@@ -4698,6 +4870,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4706,6 +4892,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -4738,6 +4930,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4974,6 +5188,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ontology-model"
@@ -6213,6 +6433,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -7812,7 +8066,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -8884,6 +9138,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -10310,6 +10570,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "jsonschema",
  "lattice-config",
  "regex",
  "serde",

--- a/DEVELOPMENT_MODEL.md
+++ b/DEVELOPMENT_MODEL.md
@@ -161,6 +161,7 @@ Documentation-to-automation drift is enforced by:
 
 ```bash
 cargo xtask architecture audit-boundaries
+cargo xtask plugin validate-manifests
 cargo xtask github audit-process
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For local enforcement parity, also run:
 
 ```bash
 cargo xtask architecture audit-boundaries
+cargo xtask plugin validate-manifests
 cargo xtask github audit-process
 ```
 

--- a/docs/process/github-governance-rollout.md
+++ b/docs/process/github-governance-rollout.md
@@ -84,6 +84,7 @@ After applying or changing governance, run:
 
 ```bash
 cargo xtask architecture audit-boundaries
+cargo xtask plugin validate-manifests
 cargo xtask github audit-process
 ```
 

--- a/docs/process/github-workflow-migration.md
+++ b/docs/process/github-workflow-migration.md
@@ -32,6 +32,7 @@ Run these from the repository root when you want local parity with the enforced 
 
 ```bash
 cargo xtask architecture audit-boundaries
+cargo xtask plugin validate-manifests
 cargo xtask github audit-process
 cargo xtask verify profile core
 cargo xtask verify profile ui

--- a/docs/process/platform-regression-guardrails.md
+++ b/docs/process/platform-regression-guardrails.md
@@ -87,5 +87,6 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-targets
 cargo xtask architecture audit-boundaries
+cargo xtask plugin validate-manifests
 cargo xtask github audit-process
 ```

--- a/docs/process/pr-conflict-reduction-playbook.md
+++ b/docs/process/pr-conflict-reduction-playbook.md
@@ -115,6 +115,7 @@ Recommended validation:
 
 ```bash
 cargo xtask architecture audit-boundaries
+cargo xtask plugin validate-manifests
 cargo xtask github audit-process
 cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 
 [dependencies]
 base64 = "0.22.1"
+jsonschema = "0.18.3"
 lattice-config = { path = "../platform/wasmcloud/lattice-config" }
 regex = "1.12.2"
 serde.workspace = true

--- a/xtask/src/github.rs
+++ b/xtask/src/github.rs
@@ -97,6 +97,7 @@ struct DocumentedProcess {
     required_issue_fields: Vec<String>,
     automatic_dev_promotion: bool,
     architecture_validation_documented: bool,
+    plugin_validation_documented: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -376,6 +377,10 @@ fn load_documented_process(workspace_root: &Path) -> Result<DocumentedProcess, S
             && contributing.contains("cargo xtask architecture audit-boundaries")
             && development.contains("cargo xtask architecture audit-boundaries")
             && workflow_migration.contains("cargo xtask architecture audit-boundaries"),
+        plugin_validation_documented: readme.contains("cargo xtask plugin validate-manifests")
+            && contributing.contains("cargo xtask plugin validate-manifests")
+            && development.contains("cargo xtask plugin validate-manifests")
+            && workflow_migration.contains("cargo xtask plugin validate-manifests"),
     })
 }
 
@@ -614,6 +619,11 @@ fn collect_audit_defects(
                 .to_owned(),
         );
     }
+    if !documented.plugin_validation_documented {
+        defects.push(
+            "contributor docs must reference `cargo xtask plugin validate-manifests`".to_owned(),
+        );
+    }
 
     defects.extend(audit_issue_templates(&documented.required_issue_fields)?);
     defects.extend(audit_pr_template(&documented.required_pr_sections)?);
@@ -687,6 +697,11 @@ fn audit_governance_workflow_for_architecture_step() -> Result<Vec<String>, Stri
     if !raw.contains("cargo xtask architecture audit-boundaries") {
         defects.push(
             "governance workflow must run `cargo xtask architecture audit-boundaries`".to_owned(),
+        );
+    }
+    if !raw.contains("cargo xtask plugin validate-manifests") {
+        defects.push(
+            "governance workflow must run `cargo xtask plugin validate-manifests`".to_owned(),
         );
     }
     Ok(defects)
@@ -766,6 +781,22 @@ fn build_drift_matrix(
             .to_owned(),
     });
 
+    rows.push(DriftRow {
+        expectation: "Governance validates governed plugin manifests".to_owned(),
+        documented_source: "README.md + CONTRIBUTING.md + docs/process/*".to_owned(),
+        automation_source: ".github/workflows/governance.yml".to_owned(),
+        status: if defects
+            .iter()
+            .any(|defect| defect.contains("plugin validate-manifests"))
+        {
+            "fail".to_owned()
+        } else {
+            "pass".to_owned()
+        },
+        details: "governance workflow should run `cargo xtask plugin validate-manifests`"
+            .to_owned(),
+    });
+
     rows
 }
 
@@ -816,7 +847,7 @@ fn render_process_audit_markdown(report: &ProcessAuditReport) -> String {
     }
 
     format!(
-        "# Process Flow Audit Report\n\n## Documented Source of Truth\n- source files: {}\n- branch model: {}\n- required checks: {}\n- required PR sections: {}\n- required issue fields: {}\n- architecture validation documented: {}\n- automatic dev promotion: {}\n\n## Defects\n{}\
+        "# Process Flow Audit Report\n\n## Documented Source of Truth\n- source files: {}\n- branch model: {}\n- required checks: {}\n- required PR sections: {}\n- required issue fields: {}\n- architecture validation documented: {}\n- plugin validation documented: {}\n- automatic dev promotion: {}\n\n## Defects\n{}\
 \n## Workflow Baseline\n{}\
 \n## Drift Matrix\n{}",
         report.documented.source_files.join(", "),
@@ -825,6 +856,11 @@ fn render_process_audit_markdown(report: &ProcessAuditReport) -> String {
         report.documented.required_pr_sections.join(", "),
         report.documented.required_issue_fields.join(", "),
         if report.documented.architecture_validation_documented {
+            "yes"
+        } else {
+            "no"
+        },
+        if report.documented.plugin_validation_documented {
             "yes"
         } else {
             "no"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ mod architecture;
 mod common;
 mod delivery;
 mod github;
+mod plugin;
 mod ui_hardening;
 
 use std::env;
@@ -62,6 +63,7 @@ fn run() -> Result<(), String> {
         Some("architecture") => architecture::run(args.collect()),
         Some("github") => github::run(args.collect()),
         Some("delivery") => delivery::run(args.collect()),
+        Some("plugin") => plugin::run(args.collect()),
         Some("wasmcloud") => run_wasmcloud(args.collect()),
         Some("ui-hardening") => ui_hardening::run(args.collect()),
         Some("ui") => run_ui(args.collect()),
@@ -609,6 +611,7 @@ usage: cargo xtask <command> ...
 Commands:
   architecture   Architecture boundary and dependency auditing
   github        GitHub governance sync, PR validation, and process auditing
+  plugin        Governed plugin manifest validation
   verify        Workspace verification profiles
   delivery      Delivery manifest and component rendering
   ui-hardening  Deterministic UI/browser hardening verification

--- a/xtask/src/plugin.rs
+++ b/xtask/src/plugin.rs
@@ -1,0 +1,398 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use jsonschema::JSONSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::common::workspace_root;
+
+#[derive(Debug, Deserialize)]
+struct PluginManifest {
+    schema_version: u32,
+    plugin_id: String,
+    app_id: String,
+    display_name: String,
+    version: String,
+    platform_contract_version: String,
+    runtime_contract_version: String,
+    ui: PluginUiContribution,
+    requested_capabilities: Vec<String>,
+    required_platform_contracts: Vec<String>,
+    service_dependencies: Vec<String>,
+    workflow_dependencies: Vec<String>,
+    host_requirements: Vec<String>,
+    runtime_targets: Vec<String>,
+    permissions: Vec<String>,
+    single_instance: bool,
+    suspend_policy: String,
+    launcher: PluginLauncher,
+    window_defaults: PluginWindowDefaults,
+}
+
+#[derive(Debug, Deserialize)]
+struct PluginUiContribution {
+    entry: String,
+    routes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PluginLauncher {
+    show_in_launcher: bool,
+    show_on_desktop: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct PluginWindowDefaults {
+    width: i32,
+    height: i32,
+}
+
+pub fn run(args: Vec<String>) -> Result<(), String> {
+    match args.as_slice() {
+        [command] if command == "validate-manifests" => validate_manifests_for_workspace(),
+        [command, path] if command == "validate-manifests" => {
+            validate_manifest_paths(vec![PathBuf::from(path)])
+        }
+        _ => Err(help()),
+    }
+}
+
+fn validate_manifests_for_workspace() -> Result<(), String> {
+    let root = workspace_root()?;
+    validate_manifest_paths(discover_plugin_manifest_paths(&root))
+}
+
+fn discover_plugin_manifest_paths(workspace_root: &Path) -> Vec<PathBuf> {
+    ["control_center", "settings", "terminal"]
+        .iter()
+        .map(|name| {
+            workspace_root
+                .join("ui")
+                .join("crates")
+                .join("apps")
+                .join(name)
+                .join("app.manifest.toml")
+        })
+        .collect()
+}
+
+fn validate_manifest_paths(paths: Vec<PathBuf>) -> Result<(), String> {
+    let workspace_root = workspace_root()?;
+    let schema_path = workspace_root.join("schemas/contracts/v1/plugin-module-v1.json");
+    let schema_raw = fs::read_to_string(&schema_path)
+        .map_err(|error| format!("failed to read `{}`: {error}", schema_path.display()))?;
+    let schema_json: Value = serde_json::from_str(&schema_raw)
+        .map_err(|error| format!("failed to parse `{}`: {error}", schema_path.display()))?;
+    let validator =
+        JSONSchema::compile(&schema_json).map_err(|error| format!("schema error: {error}"))?;
+
+    let mut defects = Vec::new();
+    for path in paths {
+        defects.extend(validate_manifest_path(&path, &validator)?);
+    }
+
+    if defects.is_empty() {
+        println!("plugin manifest validation passed");
+        Ok(())
+    } else {
+        Err(format!(
+            "plugin manifest validation found {} defect(s): {}",
+            defects.len(),
+            defects.join("; ")
+        ))
+    }
+}
+
+fn validate_manifest_path(path: &Path, validator: &JSONSchema) -> Result<Vec<String>, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read `{}`: {error}", path.display()))?;
+    let toml_value: toml::Value = toml::from_str(&raw)
+        .map_err(|error| format!("failed to parse `{}`: {error}", path.display()))?;
+    let json_value = serde_json::to_value(&toml_value)
+        .map_err(|error| format!("TOML conversion failed: {error}"))?;
+
+    let mut defects = validator
+        .validate(&json_value)
+        .err()
+        .into_iter()
+        .flatten()
+        .map(|error| {
+            format!(
+                "{}: schema violation at `{}`: {}",
+                path.display(),
+                error.instance_path,
+                error
+            )
+        })
+        .collect::<Vec<_>>();
+
+    match toml::from_str::<PluginManifest>(&raw) {
+        Ok(manifest) => defects.extend(validate_manifest_semantics(path, &manifest)),
+        Err(error) => defects.push(format!(
+            "{}: manifest deserialization failed: {error}",
+            path.display()
+        )),
+    }
+    Ok(defects)
+}
+
+fn validate_manifest_semantics(path: &Path, manifest: &PluginManifest) -> Vec<String> {
+    let mut defects = Vec::new();
+    let path = path.display();
+
+    if manifest.schema_version != 1 {
+        defects.push(format!(
+            "{path}: expected schema_version 1, found {}",
+            manifest.schema_version
+        ));
+    }
+    if manifest.plugin_id != manifest.app_id {
+        defects.push(format!(
+            "{path}: v1 plugin_id `{}` must match app_id `{}`",
+            manifest.plugin_id, manifest.app_id
+        ));
+    }
+    if manifest.display_name.trim().is_empty() {
+        defects.push(format!("{path}: display_name must not be empty"));
+    }
+    if manifest.version.trim().is_empty() {
+        defects.push(format!("{path}: version must not be empty"));
+    }
+    if !manifest.platform_contract_version.starts_with("1.") {
+        defects.push(format!(
+            "{path}: platform_contract_version must be 1.x, found `{}`",
+            manifest.platform_contract_version
+        ));
+    }
+    if !manifest.runtime_contract_version.starts_with("2.") {
+        defects.push(format!(
+            "{path}: runtime_contract_version must be 2.x, found `{}`",
+            manifest.runtime_contract_version
+        ));
+    }
+    if manifest.ui.entry.trim().is_empty() {
+        defects.push(format!("{path}: ui.entry must not be empty"));
+    }
+    if manifest.ui.routes.is_empty() {
+        defects.push(format!("{path}: ui.routes must not be empty"));
+    }
+    if manifest
+        .ui
+        .routes
+        .iter()
+        .any(|route| route.trim().is_empty())
+    {
+        defects.push(format!("{path}: ui.routes must not contain empty entries"));
+    }
+    if !manifest
+        .required_platform_contracts
+        .iter()
+        .any(|contract| contract == "schemas/contracts/v1/plugin-module-v1.json")
+    {
+        defects.push(format!(
+            "{path}: required_platform_contracts must include `schemas/contracts/v1/plugin-module-v1.json`"
+        ));
+    }
+    if manifest
+        .runtime_targets
+        .iter()
+        .any(|target| target != "pwa" && target != "tauri")
+    {
+        defects.push(format!(
+            "{path}: runtime_targets may only contain `pwa` and `tauri`: {:?}",
+            manifest.runtime_targets
+        ));
+    }
+    if !manifest
+        .runtime_targets
+        .iter()
+        .any(|target| target == "pwa")
+    {
+        defects.push(format!(
+            "{path}: runtime_targets must include baseline `pwa`"
+        ));
+    }
+    if !matches!(manifest.suspend_policy.as_str(), "never" | "on-minimize") {
+        defects.push(format!(
+            "{path}: suspend_policy must be `never` or `on-minimize`, found `{}`",
+            manifest.suspend_policy
+        ));
+    }
+    if manifest.window_defaults.width < 320 || manifest.window_defaults.height < 240 {
+        defects.push(format!(
+            "{path}: window_defaults must be at least 320x240, found {}x{}",
+            manifest.window_defaults.width, manifest.window_defaults.height
+        ));
+    }
+
+    let _ = (
+        &manifest.requested_capabilities,
+        &manifest.service_dependencies,
+        &manifest.workflow_dependencies,
+        &manifest.host_requirements,
+        &manifest.permissions,
+        manifest.single_instance,
+        manifest.launcher.show_in_launcher,
+        manifest.launcher.show_on_desktop,
+    );
+
+    defects
+}
+
+fn help() -> String {
+    "usage: cargo xtask plugin validate-manifests [path-to-manifest]".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_manifest_path, PluginManifest};
+    use jsonschema::JSONSchema;
+    use serde_json::Value;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "xtask-plugin-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock drift")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&base).expect("create temp dir");
+        base
+    }
+
+    fn load_validator() -> JSONSchema {
+        let workspace_root = crate::common::workspace_root().expect("workspace root");
+        let schema_raw =
+            fs::read_to_string(workspace_root.join("schemas/contracts/v1/plugin-module-v1.json"))
+                .expect("schema raw");
+        let schema_json: Value = serde_json::from_str(&schema_raw).expect("schema json");
+        JSONSchema::compile(&schema_json).expect("validator")
+    }
+
+    fn write_manifest(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(path, contents).expect("write manifest");
+    }
+
+    const VALID_MANIFEST: &str = r#"
+schema_version = 1
+plugin_id = "system.test"
+app_id = "system.test"
+display_name = "System Test"
+version = "0.1.0"
+platform_contract_version = "1.0.0"
+runtime_contract_version = "2.0.0"
+requested_capabilities = ["window", "state"]
+required_platform_contracts = ["schemas/contracts/v1/plugin-module-v1.json"]
+service_dependencies = []
+workflow_dependencies = []
+host_requirements = ["browser-storage:required"]
+runtime_targets = ["pwa", "tauri"]
+permissions = ["shell.mount", "shell.window"]
+single_instance = true
+suspend_policy = "never"
+
+[ui]
+entry = "desktop_app_test"
+routes = ["/apps/test"]
+
+[launcher]
+show_in_launcher = true
+show_on_desktop = true
+
+[window_defaults]
+width = 640
+height = 480
+"#;
+
+    #[test]
+    fn validates_built_in_manifests() {
+        let workspace_root = crate::common::workspace_root().expect("workspace root");
+        let validator = load_validator();
+        for path in [
+            workspace_root.join("ui/crates/apps/control_center/app.manifest.toml"),
+            workspace_root.join("ui/crates/apps/settings/app.manifest.toml"),
+            workspace_root.join("ui/crates/apps/terminal/app.manifest.toml"),
+        ] {
+            let defects = validate_manifest_path(&path, &validator).expect("validate manifest");
+            assert!(
+                defects.is_empty(),
+                "expected no defects for {}: {defects:?}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_required_fields() {
+        let root = unique_temp_dir("missing-fields");
+        let path = root.join("app.manifest.toml");
+        write_manifest(
+            &path,
+            VALID_MANIFEST
+                .replace("runtime_targets = [\"pwa\", \"tauri\"]\n", "")
+                .as_str(),
+        );
+        let defects = validate_manifest_path(&path, &load_validator()).expect("validate");
+        assert!(
+            defects
+                .iter()
+                .any(|defect| defect.contains("schema violation")),
+            "expected schema defect, got {defects:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_runtime_targets() {
+        let root = unique_temp_dir("bad-runtime");
+        let path = root.join("app.manifest.toml");
+        write_manifest(
+            &path,
+            &VALID_MANIFEST.replace(
+                "runtime_targets = [\"pwa\", \"tauri\"]",
+                "runtime_targets = [\"browser\", \"tauri\"]",
+            ),
+        );
+        let defects = validate_manifest_path(&path, &load_validator()).expect("validate");
+        assert!(
+            defects
+                .iter()
+                .any(|defect| defect.contains("runtime_targets")),
+            "expected runtime_targets defect, got {defects:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_contract_version_reference() {
+        let root = unique_temp_dir("bad-contract");
+        let path = root.join("app.manifest.toml");
+        write_manifest(
+            &path,
+            &VALID_MANIFEST.replace(
+                "platform_contract_version = \"1.0.0\"",
+                "platform_contract_version = \"2.0.0\"",
+            ),
+        );
+        let defects = validate_manifest_path(&path, &load_validator()).expect("validate");
+        assert!(
+            defects
+                .iter()
+                .any(|defect| defect.contains("platform_contract_version must be 1.x")),
+            "expected contract version defect, got {defects:?}"
+        );
+    }
+
+    #[test]
+    fn parses_valid_manifest_shape() {
+        let manifest: PluginManifest = toml::from_str(VALID_MANIFEST).expect("parse manifest");
+        assert_eq!(manifest.plugin_id, "system.test");
+        assert_eq!(manifest.ui.entry, "desktop_app_test");
+    }
+}


### PR DESCRIPTION
## Summary

Add a standalone governed plugin manifest validator to `xtask`, wire it into governance, and document it as part of the required local and CI validation surface.

## Linked Issue

Closes #92

## Layers Touched

- [ ] `enterprise`
- [ ] `schemas`
- [ ] `shared`
- [ ] `platform`
- [ ] `services`
- [ ] `workflows`
- [ ] `ui`
- [ ] `infrastructure`
- [ ] `agents`
- [ ] `testing`
- [x] `docs`
- [x] `.github` / delivery tooling

## Contracts Changed

- None. This PR validates the existing governed plugin contract at `schemas/contracts/v1/plugin-module-v1.json` without changing the contract itself.
- The validator also checks the additive desktop app registration expectations already established on `main`.

## Tests Added or Updated

- Added `xtask` plugin validation tests covering valid built-in manifests, missing required fields, invalid runtime targets, invalid contract references, and valid manifest parsing.
- Reused the existing workspace test surface by validating built-in manifests through the standalone command path.

## Refreshed from Main

- Branch refreshed from the latest target branch before review: yes
- Validation rerun after refresh: yes

## Risk Class

- medium

## Architecture Delta

- Single-plane objective centered on repository governance and validation hardening.
- This change does not introduce a new plugin model. It makes the governed plugin manifest contract independently enforceable outside the `desktop_runtime` build path.
- The sequence was: add standalone validator logic in `xtask`, wire it into governance, then update contributor/process docs so the documented workflow matches the enforced workflow.

## Workflow Checklist

- [x] This branch is based on the current target branch (`origin/main` for normal PRs, the parent branch for stacked PRs).
- [x] If this PR is stacked, the PR base points to the parent branch until that parent work merges.
- [x] If this PR touches `ui/crates/desktop_runtime`, `ui/crates/system_ui`, or `ui/crates/site/src/generated`, I rebased immediately before requesting merge.
- [x] If this PR touches `ui/`, `shared/`, `platform/`, `schemas/`, `.github/`, or `infrastructure/wasmcloud/manifests`, I refreshed from the latest target branch and reran validation immediately before requesting merge.
- [x] If this PR updates generated assets or token outputs, I regenerated them after the last rebase.

## Technical Changes

- Added `cargo xtask plugin validate-manifests` as a standalone repository-owned validator.
- Load and validate governed plugin manifests against `schemas/contracts/v1/plugin-module-v1.json`.
- Add semantic checks for runtime targets, contract references, UI routes, and core manifest metadata expected by the governed plugin model.
- Extend `cargo xtask github audit-process` so documented workflow expectations include the standalone plugin validator.
- Update `Governance / validate` to run plugin manifest validation alongside architecture and process audits.

## Testing Strategy

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets`
- `cargo xtask architecture audit-boundaries`
- `cargo xtask plugin validate-manifests`
- `cargo xtask github audit-process`

## Deployment Impact

- No workload runtime migration.
- No environment manifest changes or renames.
- Governance becomes stricter by requiring governed plugin manifests to validate independently of the desktop build path.
- Rollback is revert of this PR and rerun of the required validation checks.