### PR TITLE
refactor(workspace): enforce dependency governance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,7 +2088,7 @@ dependencies = [
  "system_shell_contract",
  "system_ui",
  "tabled",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "toml 0.8.23",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 chrono = { version = "0.4.42", features = ["clock", "serde"] }
+futures = "0.3.32"
 hex = "0.4.3"
 quick-xml = "0.38.4"
 rand = "0.9.2"

--- a/platform/sdk/sdk-rs/Cargo.toml
+++ b/platform/sdk/sdk-rs/Cargo.toml
@@ -9,14 +9,14 @@ version.workspace = true
 contracts = { path = "../../../schemas/crates/contracts" }
 error-model = { path = "../../../shared/error-model" }
 events = { path = "../../../schemas/crates/events" }
-futures = "0.3"
+futures.workspace = true
 lattice-config = { path = "../../wasmcloud/lattice-config" }
 serde.workspace = true
 
 [dev-dependencies]
 chrono = { version = "0.4.42", features = ["clock", "serde"] }
 identity = { path = "../../../shared/identity" }
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/platform/wasmcloud/smoke-tests/Cargo.toml
+++ b/platform/wasmcloud/smoke-tests/Cargo.toml
@@ -12,7 +12,7 @@ sdk-rs = { path = "../../sdk/sdk-rs" }
 treasury-disbursement = { path = "../../../workflows/treasury_disbursement" }
 
 [dev-dependencies]
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/shared/surrealdb-access/Cargo.toml
+++ b/shared/surrealdb-access/Cargo.toml
@@ -17,7 +17,7 @@ surrealdb-model = { path = "../../schemas/crates/surrealdb-model" }
 [dev-dependencies]
 chrono = { version = "0.4.42", features = ["clock", "serde"] }
 identity = { path = "../identity" }
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/ui/crates/apps/control_center/Cargo.toml
+++ b/ui/crates/apps/control_center/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "desktop_app_control_center"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["csr"]
@@ -12,6 +14,6 @@ desktop_app_contract = { path = "../../desktop_app_contract", default-features =
 leptos = { version = "0.6", default-features = false }
 platform_host = { path = "../../platform_host" }
 sdk-rs = { path = "../../../../platform/sdk/sdk-rs" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 system_ui = { path = "../../system_ui", default-features = false }

--- a/ui/crates/apps/settings/Cargo.toml
+++ b/ui/crates/apps/settings/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "desktop_app_settings"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["csr"]
@@ -11,6 +13,6 @@ csr = ["leptos/csr", "desktop_app_contract/csr"]
 desktop_app_contract = { path = "../../desktop_app_contract", default-features = false }
 leptos = { version = "0.6", default-features = false }
 platform_host = { path = "../../platform_host" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 system_ui = { path = "../../system_ui", default-features = false }

--- a/ui/crates/apps/terminal/Cargo.toml
+++ b/ui/crates/apps/terminal/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "desktop_app_terminal"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["csr"]
@@ -11,8 +13,8 @@ csr = ["leptos/csr", "desktop_app_contract/csr"]
 desktop_app_contract = { path = "../../desktop_app_contract", default-features = false }
 leptos = { version = "0.6", default-features = false }
 platform_host = { path = "../../platform_host" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 system_ui = { path = "../../system_ui", default-features = false }
 system_shell_contract = { path = "../../system_shell_contract" }
 web-sys = { version = "0.3", features = ["HtmlElement"] }

--- a/ui/crates/desktop_app_contract/Cargo.toml
+++ b/ui/crates/desktop_app_contract/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name = "desktop_app_contract"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["csr"]
 csr = ["leptos/csr"]
 
 [dependencies]
-futures = "0.3"
+futures.workspace = true
 leptos = { version = "0.6", default-features = false }
 platform_host = { path = "../platform_host" }
 sdk-rs = { path = "../../../platform/sdk/sdk-rs" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 system_shell_contract = { path = "../system_shell_contract" }

--- a/ui/crates/desktop_runtime/Cargo.toml
+++ b/ui/crates/desktop_runtime/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "desktop_runtime"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["csr"]
@@ -19,7 +21,7 @@ desktop_app_contract = { path = "../desktop_app_contract", default-features = fa
 desktop_app_control_center = { path = "../apps/control_center", default-features = false }
 desktop_app_terminal = { path = "../apps/terminal", default-features = false }
 desktop_app_settings = { path = "../apps/settings", default-features = false }
-futures = "0.3"
+futures.workspace = true
 js-sys = "0.3"
 leptos = { version = "0.6", default-features = false }
 nu-ansi-term = { version = "0.50.3", default-features = false }
@@ -28,13 +30,13 @@ nu-table = { version = "0.110.0", default-features = false }
 platform_host = { path = "../platform_host" }
 platform_host_web = { path = "../platform_host_web", default-features = false }
 sdk-rs = { path = "../../../platform/sdk/sdk-rs" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 system_ui = { path = "../system_ui", default-features = false }
 system_shell = { path = "../system_shell" }
 system_shell_contract = { path = "../system_shell_contract" }
 tabled = { version = "0.20", default-features = false, features = ["ansi"] }
-thiserror = "1"
+thiserror.workspace = true
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Document", "Element", "HtmlElement", "KeyboardEvent", "MouseEvent", "PointerEvent", "Storage", "Window"] }
 
@@ -42,6 +44,6 @@ web-sys = { version = "0.3", features = ["Document", "Element", "HtmlElement", "
 pretty_assertions = "1"
 
 [build-dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 toml = "0.8"

--- a/ui/crates/desktop_tauri/Cargo.toml
+++ b/ui/crates/desktop_tauri/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "desktop_tauri"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 description = "Tauri desktop shell host for the Origin OS Leptos runtime."
 
 [[bin]]
@@ -14,7 +16,7 @@ tauri-build = { version = "2", default-features = false, features = ["config-jso
 
 [dependencies]
 platform_host = { path = "../platform_host" }
-serde_json = "1"
+serde_json.workspace = true
 tauri = { version = "2", default-features = false, features = ["common-controls-v6", "compression", "dynamic-acl", "wry", "x11"] }
 tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"

--- a/ui/crates/platform_host/Cargo.toml
+++ b/ui/crates/platform_host/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "platform_host"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [dependencies]
 js-sys = "0.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
-futures = "0.3"
+futures.workspace = true

--- a/ui/crates/platform_host_web/Cargo.toml
+++ b/ui/crates/platform_host_web/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "platform_host_web"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [features]
 default = []
@@ -9,11 +11,11 @@ desktop-host-stub = []
 desktop-host-tauri = []
 
 [dependencies]
-futures = "0.3"
+futures.workspace = true
 js-sys = "0.3"
 platform_host = { path = "../platform_host" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/ui/crates/shrs_core_headless/Cargo.toml
+++ b/ui/crates/shrs_core_headless/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "shrs_core_headless"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true

--- a/ui/crates/system_shell/Cargo.toml
+++ b/ui/crates/system_shell/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "system_shell"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [dependencies]
-futures = "0.3"
+futures.workspace = true
 leptos = { version = "0.6", default-features = false }
-serde_json = "1"
+serde_json.workspace = true
 shrs_core_headless = { path = "../shrs_core_headless" }
 system_shell_contract = { path = "../system_shell_contract" }

--- a/ui/crates/system_shell_contract/Cargo.toml
+++ b/ui/crates/system_shell_contract/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "system_shell_contract"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true

--- a/ui/crates/system_ui/Cargo.toml
+++ b/ui/crates/system_ui/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "system_ui"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
 build = "build.rs"
 
 [features]
@@ -10,10 +12,10 @@ csr = ["leptos/csr"]
 
 [dependencies]
 leptos = { version = "0.6", default-features = false }
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 
 [build-dependencies]
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 toml = "0.8"
 
 [dev-dependencies]

--- a/xtask/src/architecture.rs
+++ b/xtask/src/architecture.rs
@@ -7,6 +7,18 @@ use crate::common::workspace_root;
 use regex::Regex;
 use serde::Deserialize;
 
+const FOUNDATIONAL_WORKSPACE_DEPENDENCIES: &[&str] = &[
+    "futures",
+    "quick-xml",
+    "reqwest",
+    "serde",
+    "serde_json",
+    "tempfile",
+    "thiserror",
+    "tokio",
+    "tracing",
+];
+
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) enum Plane {
     Enterprise,
@@ -54,15 +66,34 @@ impl Plane {
 struct ManifestDependency {
     section: String,
     name: String,
-    target_path: String,
-    plane: Plane,
+    requested_path: String,
+    target_path: Option<String>,
+    plane: Option<Plane>,
+    within_workspace: bool,
+    resolution_error: Option<String>,
 }
 
 #[derive(Debug)]
 struct MemberAudit {
     member_path: String,
     plane: Plane,
+    dependency_declarations: Vec<ManifestDependencyDeclaration>,
     dependencies: Vec<ManifestDependency>,
+    documented_workspace_exceptions: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct ManifestDependencyDeclaration {
+    section: String,
+    name: String,
+    uses_workspace_inheritance: bool,
+    explicit_version: Option<String>,
+}
+
+#[derive(Debug)]
+struct RootWorkspaceManifest {
+    members: BTreeSet<String>,
+    workspace_dependencies: BTreeSet<String>,
 }
 
 #[derive(Debug)]
@@ -133,9 +164,10 @@ pub fn run(args: Vec<String>) -> Result<(), String> {
 
 fn audit_boundaries() -> Result<(), String> {
     let workspace_root = workspace_root()?;
+    let root_manifest = read_root_workspace_manifest(&workspace_root)?;
     let audits = audit_workspace_members(&workspace_root)?;
     let metadata = load_workspace_metadata(&workspace_root)?;
-    let defects = collect_boundary_defects(&workspace_root, &audits, &metadata)?;
+    let defects = collect_boundary_defects(&workspace_root, &root_manifest, &audits, &metadata)?;
 
     if defects.is_empty() {
         println!("architecture boundary audit passed");
@@ -150,22 +182,44 @@ fn audit_boundaries() -> Result<(), String> {
 }
 
 fn audit_workspace_members(workspace_root: &Path) -> Result<Vec<MemberAudit>, String> {
+    let root_manifest = read_root_workspace_manifest(workspace_root)?;
+
+    root_manifest
+        .members
+        .iter()
+        .map(String::as_str)
+        .map(|member| audit_member(workspace_root, member))
+        .collect()
+}
+
+fn read_root_workspace_manifest(workspace_root: &Path) -> Result<RootWorkspaceManifest, String> {
     let root_manifest = fs::read_to_string(workspace_root.join("Cargo.toml"))
         .map_err(|error| format!("failed to read workspace Cargo.toml: {error}"))?;
     let root_value: toml::Value = toml::from_str(&root_manifest)
         .map_err(|error| format!("failed to parse workspace Cargo.toml: {error}"))?;
-    let members = root_value
+    let workspace = root_value
         .get("workspace")
         .and_then(toml::Value::as_table)
-        .and_then(|workspace| workspace.get("members"))
-        .and_then(toml::Value::as_array)
-        .ok_or_else(|| "workspace members are missing from root Cargo.toml".to_string())?;
+        .ok_or_else(|| "workspace table is missing from root Cargo.toml".to_string())?;
 
-    members
+    let members = workspace
+        .get("members")
+        .and_then(toml::Value::as_array)
+        .ok_or_else(|| "workspace members are missing from root Cargo.toml".to_string())?
         .iter()
         .filter_map(toml::Value::as_str)
-        .map(|member| audit_member(workspace_root, member))
-        .collect()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    let workspace_dependencies = workspace
+        .get("dependencies")
+        .and_then(toml::Value::as_table)
+        .map(|dependencies| dependencies.keys().cloned().collect())
+        .unwrap_or_default();
+
+    Ok(RootWorkspaceManifest {
+        members,
+        workspace_dependencies,
+    })
 }
 
 fn audit_member(workspace_root: &Path, member: &str) -> Result<MemberAudit, String> {
@@ -181,8 +235,95 @@ fn audit_member(workspace_root: &Path, member: &str) -> Result<MemberAudit, Stri
     Ok(MemberAudit {
         member_path: member.to_string(),
         plane: classify_member_path(member),
+        dependency_declarations: collect_manifest_declarations(&manifest),
         dependencies: collect_manifest_dependencies(workspace_root, manifest_dir, &manifest)?,
+        documented_workspace_exceptions: collect_documented_workspace_exceptions(&manifest),
     })
+}
+
+fn collect_manifest_declarations(
+    manifest: &toml::Value,
+) -> Vec<ManifestDependencyDeclaration> {
+    let mut declarations = Vec::new();
+
+    for section in ["dependencies", "dev-dependencies", "build-dependencies"] {
+        if let Some(table) = manifest.get(section).and_then(toml::Value::as_table) {
+            declarations.extend(parse_dependency_declaration_table(section, table));
+        }
+    }
+
+    if let Some(targets) = manifest.get("target").and_then(toml::Value::as_table) {
+        for (target_name, value) in targets {
+            if let Some(target_table) = value.as_table() {
+                for section in ["dependencies", "dev-dependencies", "build-dependencies"] {
+                    if let Some(table) = target_table.get(section).and_then(toml::Value::as_table) {
+                        let scoped = format!("target.{target_name}.{section}");
+                        declarations.extend(parse_dependency_declaration_table(&scoped, table));
+                    }
+                }
+            }
+        }
+    }
+
+    declarations
+}
+
+fn parse_dependency_declaration_table(
+    section: &str,
+    table: &toml::Table,
+) -> Vec<ManifestDependencyDeclaration> {
+    let mut declarations = Vec::new();
+
+    for (name, value) in table {
+        let (uses_workspace_inheritance, explicit_version) = match value {
+            toml::Value::Table(inner) => (
+                inner
+                    .get("workspace")
+                    .and_then(toml::Value::as_bool)
+                    .unwrap_or(false),
+                inner
+                    .get("version")
+                    .and_then(toml::Value::as_str)
+                    .map(str::to_owned),
+            ),
+            toml::Value::String(version) => (false, Some(version.clone())),
+            _ => (false, None),
+        };
+
+        declarations.push(ManifestDependencyDeclaration {
+            section: section.to_string(),
+            name: name.clone(),
+            uses_workspace_inheritance,
+            explicit_version,
+        });
+    }
+
+    declarations
+}
+
+fn collect_documented_workspace_exceptions(manifest: &toml::Value) -> BTreeMap<String, String> {
+    manifest
+        .get("package")
+        .and_then(toml::Value::as_table)
+        .and_then(|package| package.get("metadata"))
+        .and_then(toml::Value::as_table)
+        .and_then(|metadata| metadata.get("origin"))
+        .and_then(toml::Value::as_table)
+        .and_then(|origin| origin.get("workspace-dependency-exceptions"))
+        .and_then(toml::Value::as_table)
+        .map(|exceptions| {
+            exceptions
+                .iter()
+                .filter_map(|(name, value)| {
+                    value
+                        .as_str()
+                        .map(str::trim)
+                        .filter(|reason| !reason.is_empty())
+                        .map(|reason| (name.clone(), reason.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn collect_manifest_dependencies(
@@ -239,27 +380,50 @@ fn parse_dependency_table(
             continue;
         };
         let candidate = manifest_dir.join(path_value);
-        let resolved = fs::canonicalize(&candidate).map_err(|error| {
-            format!(
-                "failed to resolve dependency path `{}` from `{}`: {error}",
-                candidate.display(),
-                manifest_dir.display()
-            )
-        })?;
-        if !resolved.starts_with(&canonical_workspace_root) {
-            continue;
+        match fs::canonicalize(&candidate) {
+            Ok(resolved) if resolved.starts_with(&canonical_workspace_root) => {
+                let relative = resolved
+                    .strip_prefix(&canonical_workspace_root)
+                    .map_err(|error| format!("failed to strip workspace prefix: {error}"))?
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                dependencies.push(ManifestDependency {
+                    section: section.to_string(),
+                    name: name.clone(),
+                    requested_path: path_value.to_string(),
+                    target_path: Some(relative.clone()),
+                    plane: Some(classify_member_path(&relative)),
+                    within_workspace: true,
+                    resolution_error: None,
+                });
+            }
+            Ok(_) => {
+                dependencies.push(ManifestDependency {
+                    section: section.to_string(),
+                    name: name.clone(),
+                    requested_path: path_value.to_string(),
+                    target_path: None,
+                    plane: None,
+                    within_workspace: false,
+                    resolution_error: None,
+                });
+            }
+            Err(error) => {
+                dependencies.push(ManifestDependency {
+                    section: section.to_string(),
+                    name: name.clone(),
+                    requested_path: path_value.to_string(),
+                    target_path: None,
+                    plane: None,
+                    within_workspace: true,
+                    resolution_error: Some(format!(
+                        "failed to resolve dependency path `{}` from `{}`: {error}",
+                        candidate.display(),
+                        manifest_dir.display()
+                    )),
+                });
+            }
         }
-        let relative = resolved
-            .strip_prefix(&canonical_workspace_root)
-            .map_err(|error| format!("failed to strip workspace prefix: {error}"))?
-            .to_string_lossy()
-            .replace('\\', "/");
-        dependencies.push(ManifestDependency {
-            section: section.to_string(),
-            name: name.clone(),
-            plane: classify_member_path(&relative),
-            target_path: relative,
-        });
     }
 
     Ok(dependencies)
@@ -274,28 +438,35 @@ fn dependency_path(value: &toml::Value) -> Option<&str> {
 
 fn collect_boundary_defects(
     workspace_root: &Path,
+    root_manifest: &RootWorkspaceManifest,
     audits: &[MemberAudit],
     metadata: &MetadataWorkspace,
 ) -> Result<Vec<String>, String> {
-    let mut defects = Vec::new();
+    let mut defects = scan_for_manifest_governance_defects(root_manifest, audits);
 
     for audit in audits {
         let allowed = allowed_planes(audit.plane);
         for dependency in &audit.dependencies {
-            if !allowed.contains(&dependency.plane) {
-                defects.push(format!(
-                    "member `{}` in plane `{}` has disallowed {} dependency `{}` -> `{}` ({})",
-                    audit.member_path,
-                    audit.plane.as_str(),
-                    dependency.section,
-                    dependency.name,
-                    dependency.target_path,
-                    dependency.plane.as_str()
-                ));
+            if let (Some(target_path), Some(plane)) = (&dependency.target_path, dependency.plane) {
+                if !allowed.contains(&plane) {
+                    defects.push(format!(
+                        "member `{}` in plane `{}` has disallowed {} dependency `{}` -> `{}` ({})",
+                        audit.member_path,
+                        audit.plane.as_str(),
+                        dependency.section,
+                        dependency.name,
+                        target_path,
+                        plane.as_str()
+                    ));
+                }
             }
         }
     }
 
+    defects.extend(scan_for_invalid_workspace_path_dependencies(
+        root_manifest,
+        audits,
+    ));
     defects.extend(scan_for_direct_surreal_usage(workspace_root)?);
     defects.extend(scan_for_transitive_workspace_violations(metadata));
     defects.extend(scan_for_workspace_import_violations(
@@ -303,6 +474,85 @@ fn collect_boundary_defects(
         metadata,
     )?);
     Ok(defects)
+}
+
+fn scan_for_manifest_governance_defects(
+    root_manifest: &RootWorkspaceManifest,
+    audits: &[MemberAudit],
+) -> Vec<String> {
+    let foundational = FOUNDATIONAL_WORKSPACE_DEPENDENCIES
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut defects = Vec::new();
+
+    for audit in audits {
+        for declaration in &audit.dependency_declarations {
+            if declaration.uses_workspace_inheritance
+                && !root_manifest
+                    .workspace_dependencies
+                    .contains(&declaration.name)
+            {
+                defects.push(format!(
+                    "member `{}` uses workspace dependency `{}` in `{}` but root `[workspace.dependencies]` does not define it",
+                    audit.member_path, declaration.name, declaration.section
+                ));
+            }
+            if foundational.contains(declaration.name.as_str())
+                && declaration.explicit_version.is_some()
+                && !audit
+                    .documented_workspace_exceptions
+                    .contains_key(&declaration.name)
+            {
+                defects.push(format!(
+                    "member `{}` pins foundational dependency `{}` in `{}` instead of workspace inheritance",
+                    audit.member_path, declaration.name, declaration.section
+                ));
+            }
+        }
+    }
+
+    defects
+}
+
+fn scan_for_invalid_workspace_path_dependencies(
+    root_manifest: &RootWorkspaceManifest,
+    audits: &[MemberAudit],
+) -> Vec<String> {
+    let mut defects = Vec::new();
+
+    for audit in audits {
+        for dependency in &audit.dependencies {
+            if let Some(error) = &dependency.resolution_error {
+                defects.push(format!(
+                    "member `{}` has unresolved {} path dependency `{}` -> `{}`: {error}",
+                    audit.member_path,
+                    dependency.section,
+                    dependency.name,
+                    dependency.requested_path
+                ));
+                continue;
+            }
+            if !dependency.within_workspace {
+                continue;
+            }
+            let Some(target_path) = &dependency.target_path else {
+                continue;
+            };
+            let member_path = target_path
+                .strip_suffix("/Cargo.toml")
+                .unwrap_or(target_path);
+            if root_manifest.members.contains(member_path) {
+                continue;
+            }
+            defects.push(format!(
+                "member `{}` has {} path dependency `{}` -> `{}` that is not listed in workspace members",
+                audit.member_path, dependency.section, dependency.name, member_path
+            ));
+        }
+    }
+
+    defects
 }
 
 fn load_workspace_metadata(workspace_root: &Path) -> Result<MetadataWorkspace, String> {
@@ -788,8 +1038,10 @@ fn help() -> String {
 mod tests {
     use super::{
         audit_workspace_members, build_metadata_workspace, classify_member_path,
-        classify_repo_path, planes_for_paths, scan_for_transitive_workspace_violations,
-        scan_for_workspace_import_violations, CargoMetadata, Plane,
+        classify_repo_path, planes_for_paths, read_root_workspace_manifest,
+        scan_for_invalid_workspace_path_dependencies, scan_for_manifest_governance_defects,
+        scan_for_transitive_workspace_violations, scan_for_workspace_import_violations,
+        CargoMetadata, Plane,
     };
     use std::collections::BTreeSet;
     use std::fs;
@@ -920,7 +1172,7 @@ edition = "2021"
             .find(|audit| audit.member_path == "ui/app")
             .expect("ui audit");
         assert_eq!(ui_audit.dependencies.len(), 1);
-        assert_eq!(ui_audit.dependencies[0].plane, Plane::Platform);
+        assert_eq!(ui_audit.dependencies[0].plane, Some(Plane::Platform));
     }
 
     #[test]
@@ -960,7 +1212,164 @@ edition = "2021"
             .iter()
             .find(|audit| audit.member_path == "ui/app")
             .expect("ui audit");
-        assert_eq!(ui_audit.dependencies[0].plane, Plane::Services);
+        assert_eq!(ui_audit.dependencies[0].plane, Some(Plane::Services));
+    }
+
+    #[test]
+    fn manifest_governance_detects_missing_workspace_dependency_definition() {
+        let root = unique_temp_dir("missing-workspace-dep");
+        write_file(
+            &root.join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["ui/app"]
+
+[workspace.dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+"#,
+        );
+        write_file(
+            &root.join("ui/app/Cargo.toml"),
+            r#"
+[package]
+name = "ui-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio.workspace = true
+"#,
+        );
+
+        let root_manifest = read_root_workspace_manifest(&root).expect("root manifest");
+        let audits = audit_workspace_members(&root).expect("audit workspace");
+        let defects = scan_for_manifest_governance_defects(&root_manifest, &audits);
+        assert!(
+            defects
+                .iter()
+                .any(|defect| defect.contains("root `[workspace.dependencies]` does not define")),
+            "expected missing workspace dependency defect, got {defects:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_governance_detects_non_member_path_dependency() {
+        let root = unique_temp_dir("non-member-path");
+        write_file(
+            &root.join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["ui/app"]
+"#,
+        );
+        write_file(
+            &root.join("ui/app/Cargo.toml"),
+            r#"
+[package]
+name = "ui-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+helper = { path = "../../shared/helper" }
+"#,
+        );
+        write_file(
+            &root.join("shared/helper/Cargo.toml"),
+            r#"
+[package]
+name = "helper"
+version = "0.1.0"
+edition = "2021"
+"#,
+        );
+
+        let root_manifest = read_root_workspace_manifest(&root).expect("root manifest");
+        let audits = audit_workspace_members(&root).expect("audit workspace");
+        let defects = scan_for_invalid_workspace_path_dependencies(&root_manifest, &audits);
+        assert!(
+            defects
+                .iter()
+                .any(|defect| defect.contains("not listed in workspace members")),
+            "expected non-member path dependency defect, got {defects:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_governance_detects_undocumented_foundational_pin() {
+        let root = unique_temp_dir("foundational-pin");
+        write_file(
+            &root.join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["ui/app"]
+
+[workspace.dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+"#,
+        );
+        write_file(
+            &root.join("ui/app/Cargo.toml"),
+            r#"
+[package]
+name = "ui-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+"#,
+        );
+
+        let root_manifest = read_root_workspace_manifest(&root).expect("root manifest");
+        let audits = audit_workspace_members(&root).expect("audit workspace");
+        let defects = scan_for_manifest_governance_defects(&root_manifest, &audits);
+        assert!(
+            defects
+                .iter()
+                .any(|defect| defect.contains("pins foundational dependency `serde`")),
+            "expected foundational pin defect, got {defects:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_governance_allows_documented_foundational_exception() {
+        let root = unique_temp_dir("documented-exception");
+        write_file(
+            &root.join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["ui/app"]
+
+[workspace.dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+"#,
+        );
+        write_file(
+            &root.join("ui/app/Cargo.toml"),
+            r#"
+[package]
+name = "ui-app"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.origin.workspace-dependency-exceptions]
+serde = "Pinned intentionally for a temporary compatibility window."
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+"#,
+        );
+
+        let root_manifest = read_root_workspace_manifest(&root).expect("root manifest");
+        let audits = audit_workspace_members(&root).expect("audit workspace");
+        let defects = scan_for_manifest_governance_defects(&root_manifest, &audits);
+        assert!(
+            defects
+                .iter()
+                .all(|defect| !defect.contains("pins foundational dependency `serde`")),
+            "expected documented exception to suppress foundational pin defect, got {defects:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- centralize touched foundational dependencies in the root workspace manifest
- enforce manifest parity through the existing xtask architecture audit
- align touched manifests with workspace inheritance and add governance coverage

## Layers Touched
- shared
- xtask
- root workspace

## Contracts Changed
- none

## Tests Added or Updated
- xtask manifest governance tests

## Refresh-From-Main Status
- based on current `main` before branch cut; branch is isolated to workspace governance

## Risk Class
- low

## Rollout or Migration Impact
- none; this tightens build-time governance only

## Validation Artifacts
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets`
- `cargo xtask architecture audit-boundaries`
- `cargo xtask plugin validate-manifests`
- `cargo xtask github audit-process`

Closes #104
