### PR TITLE
feat(shared): add governed surrealdb runtime connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "decision-core"
 version = "0.1.0"
 dependencies = [
@@ -3324,11 +3330,13 @@ dependencies = [
 name = "governed-storage"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "contracts",
  "error-model",
  "events",
  "futures",
  "surrealdb-access",
+ "tokio",
 ]
 
 [[package]]
@@ -8538,8 +8546,10 @@ dependencies = [
  "surrealdb-core",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
+ "trice",
  "url",
  "uuid",
  "wasm-bindgen-futures",
@@ -9575,6 +9585,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9923,6 +9945,25 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ workflow.
 - [Execution Artifacts](process/execution-artifacts.md)
 - [GitHub Governance Rollout](process/github-governance-rollout.md)
 - [GitHub Workflow Migration Note](process/github-workflow-migration.md)
+- [Local wasmCloud development](process/wasmcloud-local-dev.md)
 - [Platform Regression Guardrails](process/platform-regression-guardrails.md)
 - [PR Conflict Reduction Playbook](process/pr-conflict-reduction-playbook.md)
 - [Work Item Migration](process/work-item-migration.md)

--- a/docs/architecture/runtime-composition.md
+++ b/docs/architecture/runtime-composition.md
@@ -37,9 +37,26 @@ This document defines how Origin composes at build time, at runtime, and across 
 1. A user interacts with the Leptos/WebAssembly shell.
 2. The shell resolves the active plugin module and invokes typed platform interfaces.
 3. `platform/` routes requests across host boundaries and published service/workflow contracts.
-4. wasmCloud services and workflows execute backend behavior on AWS-hosted runtime infrastructure.
-5. Cloudflare mediates public network ingress and routing to AWS-hosted workloads.
-6. Environment promotion uses digest-pinned manifests and release artifacts rather than rebuilds.
+4. `shared/governed-storage` is the only approved runtime gateway for durable SurrealDB access and
+   loads its connection contract from `ORIGIN_SURREALDB_ENDPOINT`,
+   `ORIGIN_SURREALDB_USERNAME`, `ORIGIN_SURREALDB_PASSWORD`,
+   `ORIGIN_SURREALDB_NAMESPACE`, and `ORIGIN_SURREALDB_DATABASE`.
+5. wasmCloud services and workflows execute backend behavior on AWS-hosted runtime infrastructure.
+6. Cloudflare mediates public network ingress and routing to AWS-hosted workloads.
+7. Environment promotion uses digest-pinned manifests and release artifacts rather than rebuilds.
+
+## Governed SurrealDB Connectivity
+
+- Direct SurrealDB client usage remains isolated to `shared/surrealdb-access`.
+- Runtime consumers use `shared/governed-storage::connect_from_env()` or
+  `shared/governed-storage::connect_durable(...)`; tests and local harnesses may continue using
+  `connect_in_memory()`.
+- The supported durable runtime path is a WebSocket connection to a host-installed SurrealDB
+  service, typically `ws://127.0.0.1:8000` for local and Pulumi-provisioned hosts.
+- Namespace and database selection remain explicit even when callers accept the repository defaults
+  of `short_origin` and `institutional`.
+- Connection or credential misconfiguration is treated as a configuration failure before services
+  enter normal repository operations.
 
 ## Environments and Delivery
 

--- a/docs/process/wasmcloud-local-dev.md
+++ b/docs/process/wasmcloud-local-dev.md
@@ -79,6 +79,38 @@ Run the wasmCloud smoke tests:
 cargo test -p wasmcloud-smoke-tests --all-targets
 ```
 
+## Wire Local SurrealDB Access
+
+If SurrealDB is installed on the workstation, start it as the local durable store on loopback:
+
+```bash
+surreal start \
+  --log info \
+  --bind 127.0.0.1:8000 \
+  --user root \
+  --pass "<PASSWORD>" \
+  surrealkv://$HOME/.local/share/origin/surrealdb.db
+```
+
+Export the runtime variables consumed by `shared/governed-storage::connect_from_env()`:
+
+```bash
+export ORIGIN_SURREALDB_ENDPOINT="ws://127.0.0.1:8000"
+export ORIGIN_SURREALDB_USERNAME="root"
+export ORIGIN_SURREALDB_PASSWORD="<PASSWORD>"
+export ORIGIN_SURREALDB_NAMESPACE="short_origin"
+export ORIGIN_SURREALDB_DATABASE="institutional"
+```
+
+Validate the governed storage path before starting other runtime components:
+
+```bash
+cargo test -p surrealdb-access -p governed-storage
+```
+
+The in-memory storage helper remains available for isolated tests, but local runtime verification
+should prefer the durable host-installed SurrealDB path above.
+
 ## Render a Development Lattice Manifest
 
 Render a development manifest with explicit component references and digests:

--- a/infrastructure/pulumi/README.md
+++ b/infrastructure/pulumi/README.md
@@ -44,6 +44,23 @@ pulumi config set --secret origin:surrealdbRootPassword "<PASSWORD>"
 ./scripts/deploy.sh dev
 ```
 
+## Runtime Client Contract
+
+Pulumi-configured hosts install and start SurrealDB on `127.0.0.1:8000` with root credentials
+from `origin:surrealdbRootPassword`. Runtime consumers in the repository connect through the
+governed shared storage layer and should receive these environment variables:
+
+```bash
+export ORIGIN_SURREALDB_ENDPOINT="ws://127.0.0.1:8000"
+export ORIGIN_SURREALDB_USERNAME="root"
+export ORIGIN_SURREALDB_PASSWORD="<origin:surrealdbRootPassword>"
+export ORIGIN_SURREALDB_NAMESPACE="short_origin"
+export ORIGIN_SURREALDB_DATABASE="institutional"
+```
+
+Do not add direct SurrealDB client usage outside `shared/surrealdb-access`; services and workflows
+should consume the governed connection helpers exposed by `shared/governed-storage`.
+
 ## Required Environment Variables
 
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` (or OIDC in CI)

--- a/plans/123-surrealdb-host-integration/EXEC_PLAN.md
+++ b/plans/123-surrealdb-host-integration/EXEC_PLAN.md
@@ -1,0 +1,36 @@
+# Execution Plan
+
+## Summary
+- Integrate the host-installed SurrealDB service into the governed storage layer by adding a durable connection configuration surface, preserving the existing in-memory helpers for tests, and documenting the runtime/infrastructure contract required for reliable service interaction.
+- Risk tier: `medium` with multi-plane execution across `shared/`, `infrastructure/`, `docs/`, and supporting repository metadata because the change affects the primary system-of-record path but remains additive.
+- Architectural references: `ARCHITECTURE.md`, `docs/architecture/layer-boundaries.md`, `docs/architecture/runtime-composition.md`, `docs/adr/0004-wasmcloud-first-ui-shell.md`, `docs/adr/0007-consistency-semantics-by-criticality.md`, `docs/adr/0010-durable-workflow-execution-plane.md`.
+
+## Task Contract
+- Task contract: `plans/123-surrealdb-host-integration/task-contract.json`
+- GitHub issue: `#123`
+- Branch: `feature/123-surrealdb-host-integration`
+
+## Scope Boundaries
+- Allowed touchpoints are limited to `shared/`, `platform/`, `services/`, `workflows/`, `infrastructure/`, `docs/`, `plans/`, `Cargo.toml`, `Cargo.lock`, and `README.md`.
+- The implementation keeps all direct SurrealDB client usage inside `shared/surrealdb-access` and any governed higher-level connection helpers inside `shared/governed-storage`.
+- Non-goals are adding UI database access, changing canonical schema ownership, or introducing a new managed-database topology.
+
+## Implementation Slices
+- Add typed durable connection configuration and validation in `shared/surrealdb-access`, including explicit namespace/database selection and a health check that can confirm the host-installed database is reachable.
+- Expose the governed durable connection path from `shared/governed-storage` while preserving the test-only in-memory helper so existing service and workflow tests remain deterministic.
+- Update or add tests that prove missing or invalid durable connection settings fail deterministically and that the in-memory helper remains available for local harnesses.
+- Update repository and infrastructure-facing docs so operators know which environment variables, host bindings, and validation commands the runtime expects for the SurrealDB host service.
+
+## Validation Plan
+- Run `cargo fmt --all --check`.
+- Run `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
+- Run `cargo test --workspace --all-targets`.
+- Run `cargo verify-repo`.
+- Capture targeted test evidence for `shared/surrealdb-access` and `shared/governed-storage`.
+
+## Rollout and Rollback
+- Rollout is additive: merge after required checks pass, then use the durable connection helper in runtime-facing integration points while keeping in-memory helpers for tests only.
+- Rollback is a single revert of the shared storage connection/configuration changes, related tests, and documentation so the repository returns to the previous in-memory-only baseline without mixed assumptions.
+
+## Open Questions
+- Determine whether the current workspace needs any additional runtime consumer wiring beyond the shared storage layer once the durable connection helper exists.

--- a/plans/123-surrealdb-host-integration/task-contract.json
+++ b/plans/123-surrealdb-host-integration/task-contract.json
@@ -1,0 +1,75 @@
+{
+  "issue_id": 123,
+  "issue_url": "https://github.com/shortorigin/origin/issues/123",
+  "branch": "feature/123-surrealdb-host-integration",
+  "primary_architectural_plane": "cross-layer",
+  "owning_subsystem": "governed SurrealDB connectivity across shared storage, runtime-facing configuration, and infrastructure documentation",
+  "architectural_references": [
+    "ARCHITECTURE.md",
+    "docs/architecture/layer-boundaries.md",
+    "docs/architecture/runtime-composition.md",
+    "docs/adr/0004-wasmcloud-first-ui-shell.md",
+    "docs/adr/0007-consistency-semantics-by-criticality.md",
+    "docs/adr/0010-durable-workflow-execution-plane.md"
+  ],
+  "allowed_touchpoints": [
+    "shared/",
+    "platform/",
+    "services/",
+    "workflows/",
+    "infrastructure/",
+    "docs/",
+    "plans/",
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md"
+  ],
+  "non_goals": [
+    "Do not add direct SurrealDB usage outside shared/surrealdb-access.",
+    "Do not introduce ui/ database connectivity or service-local query strings.",
+    "Do not redesign schema contracts or replace the host-installed SurrealDB deployment model."
+  ],
+  "scope_in": [
+    "Add typed durable SurrealDB connection configuration in the shared access layer.",
+    "Expose governed durable connection helpers alongside the existing test-only in-memory helpers.",
+    "Add connection validation and targeted tests for namespace, database, and connectivity handling.",
+    "Document host-installed SurrealDB runtime expectations, validation, and rollback guidance."
+  ],
+  "scope_out": [
+    "Managed database provisioning outside the current infrastructure model.",
+    "UI feature work or direct database reads from ui/.",
+    "Unrelated contract or workflow redesign."
+  ],
+  "target_paths": [
+    "shared/",
+    "platform/",
+    "services/",
+    "workflows/",
+    "infrastructure/",
+    "docs/",
+    "plans/",
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md"
+  ],
+  "acceptance_criteria": [
+    "Shared runtime code can connect to a host-installed SurrealDB instance through an explicit governed configuration surface.",
+    "Durable connection setup applies namespace and database selection and reports configuration failures deterministically.",
+    "Tests preserve the in-memory path for local harnesses while adding coverage for durable configuration behavior.",
+    "Repository documentation explains the host integration path, required environment variables, validation commands, and rollback expectations."
+  ],
+  "validation_commands": [
+    "cargo fmt --all --check",
+    "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+    "cargo test --workspace --all-targets",
+    "cargo verify-repo"
+  ],
+  "validation_artifacts": [
+    "Passing surrealdb-access and governed-storage test output",
+    "Updated repository docs for SurrealDB host integration",
+    "Committed execution artifact bundle under plans/123-surrealdb-host-integration/"
+  ],
+  "rollback_path": "Revert the shared storage integration, runtime-facing configuration, tests, and documentation together so the repository returns to the previous in-memory-only storage baseline.",
+  "exec_plan_required": true,
+  "exec_plan_path": "plans/123-surrealdb-host-integration/EXEC_PLAN.md"
+}

--- a/shared/governed-storage/Cargo.toml
+++ b/shared/governed-storage/Cargo.toml
@@ -12,5 +12,9 @@ events = { path = "../../schemas/crates/events" }
 futures.workspace = true
 storage_backend = { package = "surrealdb-access", path = "../surrealdb-access" }
 
+[dev-dependencies]
+chrono.workspace = true
+tokio.workspace = true
+
 [lints]
 workspace = true

--- a/shared/governed-storage/src/lib.rs
+++ b/shared/governed-storage/src/lib.rs
@@ -55,10 +55,28 @@ impl<B> GovernedKnowledgeStore<B> {
 
 pub type InMemoryKnowledgeStore =
     GovernedKnowledgeStore<storage_backend::InMemoryKnowledgeStoreBackend>;
+pub type DurableKnowledgeStore =
+    GovernedKnowledgeStore<storage_backend::DurableKnowledgeStoreBackend>;
+
+pub use storage_backend::SurrealConnectionConfig;
 
 pub async fn connect_in_memory() -> InstitutionalResult<InMemoryKnowledgeStore> {
     Ok(GovernedKnowledgeStore::new(
         storage_backend::connect_in_memory().await?,
+    ))
+}
+
+pub async fn connect_durable(
+    config: &SurrealConnectionConfig,
+) -> InstitutionalResult<DurableKnowledgeStore> {
+    Ok(GovernedKnowledgeStore::new(
+        storage_backend::connect_durable(config).await?,
+    ))
+}
+
+pub async fn connect_from_env() -> InstitutionalResult<DurableKnowledgeStore> {
+    Ok(GovernedKnowledgeStore::new(
+        storage_backend::connect_durable_from_env().await?,
     ))
 }
 
@@ -170,5 +188,54 @@ where
             self.inner.knowledge_edges().store(edge).await?;
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use contracts::{Classification, KnowledgeCapsuleV1};
+
+    use super::{connect_durable, KnowledgeStore, SurrealConnectionConfig};
+
+    #[tokio::test]
+    async fn durable_governed_store_supports_runtime_connection_path() {
+        let store = connect_durable(&SurrealConnectionConfig {
+            endpoint: "mem://".to_string(),
+            namespace: "runtime".to_string(),
+            database: "governed".to_string(),
+            username: None,
+            password: None,
+        })
+        .await
+        .expect("store");
+
+        store
+            .store_capsule(KnowledgeCapsuleV1 {
+                capsule_id: "capsule-runtime-1".to_string(),
+                publication_id: "publication-runtime-1".to_string(),
+                title: "Runtime capsule".to_string(),
+                source_ids: vec!["source-runtime-1".to_string()],
+                source_count: 1,
+                storage_ref: "memvid:capsule-runtime-1".to_string(),
+                artifact_hash: "capsule-runtime-hash".to_string(),
+                version: "v1".to_string(),
+                memvid_version: "2.0.138".to_string(),
+                published_at: Utc
+                    .with_ymd_and_hms(2026, 3, 10, 12, 0, 0)
+                    .single()
+                    .expect("time"),
+                classification: Classification::Internal,
+                retention_class: "institutional_record".to_string(),
+            })
+            .await
+            .expect("store capsule");
+
+        let loaded = store
+            .load_capsule("capsule-runtime-1")
+            .await
+            .expect("load capsule")
+            .expect("capsule present");
+        assert_eq!(loaded.title, "Runtime capsule");
     }
 }

--- a/shared/surrealdb-access/Cargo.toml
+++ b/shared/surrealdb-access/Cargo.toml
@@ -11,7 +11,7 @@ error-model = { path = "../error-model" }
 events = { path = "../../schemas/crates/events" }
 serde.workspace = true
 serde_json.workspace = true
-surrealdb = { version = "2.2.1", default-features = false, features = ["kv-mem"] }
+surrealdb = { version = "2.2.1", default-features = false, features = ["kv-mem", "protocol-ws"] }
 surrealdb-model = { path = "../../schemas/crates/surrealdb-model" }
 
 [dev-dependencies]

--- a/shared/surrealdb-access/src/lib.rs
+++ b/shared/surrealdb-access/src/lib.rs
@@ -2,9 +2,11 @@ use contracts::{
     EvidenceManifestV1, KnowledgeCapsuleV1, KnowledgeEdgeV1, KnowledgePublicationStatusV1,
     KnowledgeSourceV1, MacroFinancialAnalysisV1, TreasuryDisbursementRecordedV1,
 };
-use error_model::{InstitutionalError, InstitutionalResult};
+use error_model::{InstitutionalError, InstitutionalResult, OperationContext};
 use events::RecordedEventV1;
+use surrealdb::engine::any::{self, Any};
 use surrealdb::engine::local::{Db, Mem};
+use surrealdb::opt::auth::Root;
 use surrealdb::{Connection, Surreal};
 use surrealdb_model::{
     EventRecordV1, EvidenceManifestRecordV1, KnowledgeAnalysisRecordV1, KnowledgeCapsuleRecordV1,
@@ -14,11 +16,17 @@ use surrealdb_model::{
 
 pub const DEFAULT_NAMESPACE: &str = "short_origin";
 pub const DEFAULT_DATABASE: &str = "institutional";
+pub const ENV_ENDPOINT: &str = "ORIGIN_SURREALDB_ENDPOINT";
+pub const ENV_NAMESPACE: &str = "ORIGIN_SURREALDB_NAMESPACE";
+pub const ENV_DATABASE: &str = "ORIGIN_SURREALDB_DATABASE";
+pub const ENV_USERNAME: &str = "ORIGIN_SURREALDB_USERNAME";
+pub const ENV_PASSWORD: &str = "ORIGIN_SURREALDB_PASSWORD";
 
 pub use surrealdb::Connection as BackendConnection;
 
 pub type KnowledgeStoreBackend<C> = SurrealRepositoryContext<C>;
 pub type InMemoryKnowledgeStoreBackend = SurrealRepositoryContext<Db>;
+pub type DurableKnowledgeStoreBackend = SurrealRepositoryContext<Any>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TableCatalog {
@@ -42,6 +50,84 @@ pub const TABLES: TableCatalog = TableCatalog {
     knowledge_analysis: "knowledge_analysis",
     knowledge_edge: "knowledge_edge",
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SurrealConnectionConfig {
+    pub endpoint: String,
+    pub namespace: String,
+    pub database: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+impl SurrealConnectionConfig {
+    pub fn from_env() -> InstitutionalResult<Self> {
+        Self::from_env_with(|key| std::env::var(key).ok())
+    }
+
+    fn from_env_with<F>(mut read: F) -> InstitutionalResult<Self>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let endpoint = read_required_env(&mut read, ENV_ENDPOINT)?;
+        let namespace = read_optional_env(&mut read, ENV_NAMESPACE)
+            .unwrap_or_else(|| DEFAULT_NAMESPACE.to_string());
+        let database = read_optional_env(&mut read, ENV_DATABASE)
+            .unwrap_or_else(|| DEFAULT_DATABASE.to_string());
+        let username = read_optional_env(&mut read, ENV_USERNAME);
+        let password = read_optional_env(&mut read, ENV_PASSWORD);
+        let config = Self {
+            endpoint,
+            namespace,
+            database,
+            username,
+            password,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> InstitutionalResult<()> {
+        if self.endpoint.trim().is_empty() {
+            return Err(configuration_error(
+                "load-connection-config",
+                format!("environment variable `{ENV_ENDPOINT}` must not be empty"),
+            ));
+        }
+        if !supported_endpoint(self.endpoint.as_str()) {
+            return Err(configuration_error(
+                "load-connection-config",
+                format!(
+                    "endpoint `{}` is not supported; use `ws://`, `wss://`, `mem://`, or `memory`",
+                    self.endpoint
+                ),
+            ));
+        }
+        if self.namespace.trim().is_empty() {
+            return Err(configuration_error(
+                "load-connection-config",
+                "SurrealDB namespace must not be empty",
+            ));
+        }
+        if self.database.trim().is_empty() {
+            return Err(configuration_error(
+                "load-connection-config",
+                "SurrealDB database must not be empty",
+            ));
+        }
+        if requires_root_auth(self.endpoint.as_str())
+            && (self.username.is_none() || self.password.is_none())
+        {
+            return Err(configuration_error(
+                "load-connection-config",
+                format!(
+                    "remote SurrealDB endpoints require both `{ENV_USERNAME}` and `{ENV_PASSWORD}`"
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
 
 pub struct SurrealRepositoryContext<C>
 where
@@ -76,6 +162,14 @@ where
             .use_db(database)
             .await
             .map_err(surreal_error)?;
+        Ok(())
+    }
+
+    pub async fn healthcheck(&self) -> InstitutionalResult<()> {
+        self.db
+            .health()
+            .await
+            .map_err(|error| surreal_operation_error("health", error))?;
         Ok(())
     }
 
@@ -143,6 +237,43 @@ pub async fn connect_in_memory() -> InstitutionalResult<SurrealRepositoryContext
         .use_namespace(DEFAULT_NAMESPACE, DEFAULT_DATABASE)
         .await?;
     Ok(context)
+}
+
+pub async fn connect_durable(
+    config: &SurrealConnectionConfig,
+) -> InstitutionalResult<SurrealRepositoryContext<Any>> {
+    config.validate()?;
+    let db = any::connect(config.endpoint.clone())
+        .await
+        .map_err(|error| surreal_operation_error("connect", error))?;
+    if requires_root_auth(config.endpoint.as_str()) {
+        let username = config.username.as_deref().ok_or_else(|| {
+            configuration_error(
+                "connect",
+                format!("missing `{ENV_USERNAME}` for remote SurrealDB endpoint"),
+            )
+        })?;
+        let password = config.password.as_deref().ok_or_else(|| {
+            configuration_error(
+                "connect",
+                format!("missing `{ENV_PASSWORD}` for remote SurrealDB endpoint"),
+            )
+        })?;
+        db.signin(Root { username, password })
+            .await
+            .map_err(|error| surreal_operation_error("signin", error))?;
+    }
+    let context = SurrealRepositoryContext::new(db);
+    context.healthcheck().await?;
+    context
+        .use_namespace(config.namespace.as_str(), config.database.as_str())
+        .await?;
+    Ok(context)
+}
+
+pub async fn connect_durable_from_env() -> InstitutionalResult<SurrealRepositoryContext<Any>> {
+    let config = SurrealConnectionConfig::from_env()?;
+    connect_durable(&config).await
 }
 
 pub struct WorkflowExecutionRepository<C>
@@ -477,8 +608,53 @@ where
     response.take(0).map_err(surreal_error)
 }
 
+fn read_required_env<F>(read: &mut F, key: &str) -> InstitutionalResult<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    read_optional_env(read, key).ok_or_else(|| {
+        configuration_error(
+            "load-connection-config",
+            format!("environment variable `{key}` is required"),
+        )
+    })
+}
+
+fn read_optional_env<F>(read: &mut F, key: &str) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    read(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn supported_endpoint(endpoint: &str) -> bool {
+    let endpoint = endpoint.trim().to_ascii_lowercase();
+    endpoint == "memory"
+        || endpoint == "mem://"
+        || endpoint.starts_with("ws://")
+        || endpoint.starts_with("wss://")
+}
+
+fn requires_root_auth(endpoint: &str) -> bool {
+    let endpoint = endpoint.trim().to_ascii_lowercase();
+    endpoint.starts_with("ws://") || endpoint.starts_with("wss://")
+}
+
+fn configuration_error(operation: &'static str, message: impl Into<String>) -> InstitutionalError {
+    InstitutionalError::configuration(
+        OperationContext::new("shared/surrealdb-access", operation),
+        message,
+    )
+}
+
 fn surreal_error(error: surrealdb::Error) -> InstitutionalError {
     InstitutionalError::external("surrealdb", None, error.to_string())
+}
+
+fn surreal_operation_error(operation: &'static str, error: surrealdb::Error) -> InstitutionalError {
+    InstitutionalError::external("surrealdb", Some(operation.to_string()), error.to_string())
 }
 
 #[cfg(test)]
@@ -864,5 +1040,73 @@ mod tests {
             .await
             .expect("store edge");
         assert_eq!(edge.edge.from_id, "analysis-1");
+    }
+
+    #[test]
+    fn durable_config_from_env_defaults_namespace_and_database() {
+        let values = std::collections::BTreeMap::from([
+            (ENV_ENDPOINT.to_string(), "ws://127.0.0.1:8000".to_string()),
+            (ENV_USERNAME.to_string(), "root".to_string()),
+            (ENV_PASSWORD.to_string(), "root-password".to_string()),
+        ]);
+        let config =
+            SurrealConnectionConfig::from_env_with(|key| values.get(key).cloned()).expect("config");
+
+        assert_eq!(config.endpoint, "ws://127.0.0.1:8000");
+        assert_eq!(config.namespace, DEFAULT_NAMESPACE);
+        assert_eq!(config.database, DEFAULT_DATABASE);
+    }
+
+    #[test]
+    fn durable_config_requires_remote_credentials() {
+        let error = SurrealConnectionConfig {
+            endpoint: "ws://127.0.0.1:8000".to_string(),
+            namespace: DEFAULT_NAMESPACE.to_string(),
+            database: DEFAULT_DATABASE.to_string(),
+            username: None,
+            password: None,
+        }
+        .validate()
+        .expect_err("remote credentials required");
+
+        assert_eq!(
+            error.category(),
+            error_model::InstitutionalErrorCategory::Configuration
+        );
+        assert!(error.to_string().contains(ENV_USERNAME));
+    }
+
+    #[tokio::test]
+    async fn durable_connection_supports_memory_endpoint_for_runtime_path() {
+        let context = connect_durable(&SurrealConnectionConfig {
+            endpoint: "mem://".to_string(),
+            namespace: DEFAULT_NAMESPACE.to_string(),
+            database: DEFAULT_DATABASE.to_string(),
+            username: None,
+            password: None,
+        })
+        .await
+        .expect("durable memory connection");
+
+        context.healthcheck().await.expect("healthcheck");
+
+        let stored = context
+            .workflow_executions()
+            .store(WorkflowExecutionRecordV1 {
+                id: "wf-durable-1".to_string(),
+                workflow_name: "knowledge_publication".to_string(),
+                trace_ref: "trace-durable-1".to_string(),
+            })
+            .await
+            .expect("store workflow");
+        assert_eq!(stored.id, "wf-durable-1");
+
+        let loaded = context
+            .workflow_executions()
+            .load("wf-durable-1")
+            .await
+            .expect("load workflow")
+            .expect("workflow present");
+        assert_eq!(loaded.workflow_name, "knowledge_publication");
     }
 }


### PR DESCRIPTION
## Summary
Add a governed durable SurrealDB connection path in the shared storage layer, preserve the existing in-memory helper for tests, and document the host-installed runtime contract used by services and workflows.

## Linked Issue

Closes #123

## Execution Artifacts

- Task contract: `plans/123-surrealdb-host-integration/task-contract.json`
- Exec plan: `plans/123-surrealdb-host-integration/EXEC_PLAN.md`

## ADR References

- `docs/adr/0004-wasmcloud-first-ui-shell.md`
- `docs/adr/0007-consistency-semantics-by-criticality.md`
- `docs/adr/0010-durable-workflow-execution-plane.md`

## Impacted Domains

- `runtime-consistency`
- `data_knowledge`
- `governed platform storage`

## Layers Touched

- [ ] `enterprise`
- [ ] `schemas`
- [x] `shared`
- [ ] `platform`
- [ ] `services`
- [ ] `workflows`
- [ ] `ui`
- [x] `infrastructure`
- [ ] `agents`
- [ ] `testing`
- [x] `docs`
- [ ] `.github` / delivery tooling

## Contracts Changed

- None.

## Tests Added or Updated

- Added durable configuration and runtime-path tests in `shared/surrealdb-access`.
- Added a governed durable-store round-trip test in `shared/governed-storage`.

## Refreshed from Main

- Branch refreshed from the latest target branch before review: yes
- Validation rerun after refresh: yes

## Risk Class

- medium

## Affected Consistency Class

- Class A

## Affected Risk Tier

- medium

## Architecture Delta

- Dominant plane: `shared`.
- The change also touched `docs/` and `infrastructure/` documentation because the runtime connection contract and the host-installed SurrealDB deployment assumptions must remain aligned; splitting those updates would leave the executable storage layer and operator guidance out of sync.

## Workflow Checklist

- [x] This branch is based on the current target branch (`origin/main` for normal PRs, the parent branch for stacked PRs).
- [ ] If this PR is stacked, the PR base points to the parent branch until that parent work merges.
- [ ] If this PR touches `ui/crates/desktop_runtime`, `ui/crates/system_ui`, or `ui/crates/site/src/generated`, I rebased immediately before requesting merge.
- [x] If this PR touches `ui/`, `shared/`, `platform/`, `schemas/`, `.github/`, or `infrastructure/wasmcloud/manifests`, I refreshed from the latest target branch and reran validation immediately before requesting merge.
- [ ] If this PR updates generated assets or token outputs, I regenerated them after the last rebase.

## Technical Changes

- Added `SurrealConnectionConfig` and `connect_durable` / `connect_durable_from_env` in `shared/surrealdb-access` with explicit endpoint, namespace, database, and root-credential validation.
- Added `healthcheck()` on the shared repository context so runtime callers can fail fast when the host-installed SurrealDB service is unreachable.
- Exposed `connect_durable` and `connect_from_env` from `shared/governed-storage` as the approved durable runtime entrypoints for services and workflows.
- Enabled SurrealDB WebSocket support in the shared access crate while keeping the in-memory backend available for tests and local harnesses.
- Added architecture, local-development, and Pulumi runtime-client documentation for the `ORIGIN_SURREALDB_*` environment contract.

## Testing Strategy

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p surrealdb-access -p governed-storage`
- `cargo verify-repo`

## Rollback Path

- Revert the shared storage connection/configuration changes, related tests, and documentation together so the repository returns to the prior in-memory-only storage baseline.

## Validation Artifacts

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p surrealdb-access -p governed-storage`
- `cargo verify-repo`
- Process audit output under `target/process-audit`

## Deployment Impact

- No schema or UI rollout impact.
- Runtime deployments that want durable SurrealDB access must provide `ORIGIN_SURREALDB_ENDPOINT`, `ORIGIN_SURREALDB_USERNAME`, `ORIGIN_SURREALDB_PASSWORD`, and optionally `ORIGIN_SURREALDB_NAMESPACE` / `ORIGIN_SURREALDB_DATABASE`.
